### PR TITLE
feat: create WebviewCookiesManager to manage webview cookies

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -42,6 +42,8 @@ private protocol WebContentController {
 }
 
 // A class should implement AlwaysRequireAuthenticationOverriding protocol if it always require authentication.
+// This will ignore the WebviewCookiesManager session and make a new /oauth2/login/ request within the webview
+// In normal cases this shouldn't be implemented
 protocol AuthenticatedWebViewControllerRequireAuthentication {
     func alwaysRequireAuth() -> Bool
 }
@@ -126,6 +128,7 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
     weak var ajaxCallbackDelegate: AJAXCompletionCallbackDelegate?
     weak var webViewNavigationResponseDelegate: WebViewNavigationResponseDelegate?
     private lazy var configurations = environment.config.webViewConfiguration()
+    private let cookiesManager = WebviewCookiesManager.shared
     
     private var shouldListenForAjaxCallbacks = false
     
@@ -202,6 +205,37 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
     private func addObservers() {
         NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_DYNAMIC_TEXT_TYPE_UPDATE) { (_, observer, _) in
             observer.reload()
+        }
+
+        NotificationCenter.default.oex_addObserver(observer: self, name: WebviewCookiesCreatedNotification) { (_, observer, _) in
+            if observer.cookiesManager.cookiesState == .failed {
+                observer.showError(with: .failed())
+            }
+            else {
+                observer.syncCookiesStorage()
+            }
+        }
+    }
+
+    // Sync cookies between HTTview PCookieStorage and WKHTTPCookieStore
+    private func syncCookiesStorage() {
+        let cookies = HTTPCookieStorage.shared.cookies
+        DispatchQueue.global().async { [weak self] in
+            let semaphore = DispatchSemaphore(value: 0)
+            for cookie in cookies ?? [] {
+                if let webview = self?.webController.view as? WKWebView {
+                    DispatchQueue.main.async {
+                        webview.configuration.websiteDataStore.httpCookieStore.setCookie(cookie) {
+                            semaphore.signal()
+                        }
+                    }
+                }
+                semaphore.wait()
+            }
+            DispatchQueue.main.async {
+                self?.cookiesManager.updateSessionState(state: .created)
+                self?.reload()
+            }
         }
     }
 
@@ -303,15 +337,23 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
     
     public func loadRequest(request : NSURLRequest) {
         contentRequest = request
-        loadController.state = .Initial
-        state = webController.initialContentState
-        
-        var isAuthRequestRequired = webController.alwaysRequiresOAuthUpdate
+        var ignoreCookiesManager = webController.alwaysRequiresOAuthUpdate
         if let parent = parent as? AuthenticatedWebViewControllerRequireAuthentication {
-            isAuthRequestRequired = parent.alwaysRequireAuth()
+            ignoreCookiesManager = parent.alwaysRequireAuth()
         }
 
-        if isAuthRequestRequired {
+        let cookiesExpired = cookiesManager.cookiesExpired
+        if cookiesExpired && ignoreCookiesManager {
+            if cookiesManager.cookiesState != .creating && cookiesManager.cookiesState != .cookiesSet {
+                cookiesManager.createOrUpdateCookies()
+            }
+            return
+        }
+
+        loadController.state = .Initial
+        state = webController.initialContentState
+
+        if ignoreCookiesManager {
             state = State.CreatingSession
             loadOAuthRefreshRequest()
         }
@@ -379,7 +421,9 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
             }
         case .NeedingSession:
             state = .CreatingSession
-            loadOAuthRefreshRequest()
+            if cookiesManager.cookiesState != .creating && cookiesManager.cookiesState != .cookiesSet {
+                cookiesManager.createOrUpdateCookies()
+            }
         }
         
         refreshAccessibility()

--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -217,7 +217,7 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
         }
     }
 
-    // Sync cookies between HTTview PCookieStorage and WKHTTPCookieStore
+    // Sync cookies between HTTPCookieStorage and WKHTTPCookieStore
     private func syncCookiesStorage() {
         let cookies = HTTPCookieStorage.shared.cookies
         DispatchQueue.global().async { [weak self] in
@@ -342,8 +342,7 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
             ignoreCookiesManager = parent.alwaysRequireAuth()
         }
 
-        let cookiesExpired = cookiesManager.cookiesExpired
-        if cookiesExpired && ignoreCookiesManager {
+        if cookiesManager.cookiesExpired && !ignoreCookiesManager {
             if cookiesManager.cookiesState != .creating && cookiesManager.cookiesState != .cookiesSet {
                 cookiesManager.createOrUpdateCookies()
             }

--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -343,7 +343,7 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
         }
 
         if cookiesManager.cookiesExpired && !ignoreCookiesManager {
-            if cookiesManager.cookiesState != .creating && cookiesManager.cookiesState != .cookiesSet {
+            if cookiesManager.cookiesState != .creating && cookiesManager.cookiesState != .sync {
                 cookiesManager.createOrUpdateCookies()
             }
             return
@@ -420,7 +420,7 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
             }
         case .NeedingSession:
             state = .CreatingSession
-            if cookiesManager.cookiesState != .creating && cookiesManager.cookiesState != .cookiesSet {
+            if cookiesManager.cookiesState != .creating && cookiesManager.cookiesState != .sync {
                 cookiesManager.createOrUpdateCookies()
             }
         }

--- a/Source/BannerViewController.swift
+++ b/Source/BannerViewController.swift
@@ -36,13 +36,11 @@ class BannerViewController: UIViewController, InterfaceOrientationOverriding {
     private let environment: Environment
     private let url: URL
     weak var delegate: BannerViewControllerDelegate?
-    fileprivate var authRequired: Bool = false
     private var showNavbar: Bool = false
     
-    init(url: URL, title: String?, environment: Environment, alwaysRequireAuth: Bool = false, showNavbar: Bool = false) {
+    init(url: URL, title: String?, environment: Environment, showNavbar: Bool = false) {
         self.environment = environment
         self.url = url
-        self.authRequired = alwaysRequireAuth
         self.showNavbar = showNavbar
 
         super.init(nibName: nil, bundle: nil)
@@ -159,12 +157,6 @@ extension BannerViewController: WebViewNavigationResponseDelegate {
             webController.showError(with: state)
             return true
         }
-    }
-}
-
-extension BannerViewController: AuthenticatedWebViewControllerRequireAuthentication {
-    func alwaysRequireAuth() -> Bool {
-        return authRequired
     }
 }
 

--- a/Source/BrowserViewController.swift
+++ b/Source/BrowserViewController.swift
@@ -12,7 +12,7 @@ protocol BrowserViewControllerDelegate: AnyObject {
     func didDismissBrowser()
 }
 
-class BrowserViewController: UIViewController, InterfaceOrientationOverriding, AuthenticatedWebViewControllerRequireAuthentication {
+class BrowserViewController: UIViewController, InterfaceOrientationOverriding {
     
     typealias Environment = OEXAnalyticsProvider & OEXConfigProvider & OEXSessionProvider & ReachabilityProvider & OEXStylesProvider
     
@@ -20,13 +20,11 @@ class BrowserViewController: UIViewController, InterfaceOrientationOverriding, A
     
     private let url: URL
     private let environment: Environment
-    private var authRequired: Bool = false
     weak var delegate: BrowserViewControllerDelegate?
     
     init(title: String? = nil, url: URL, environment: Environment, alwaysRequireAuth: Bool = false) {
         self.url = url
         self.environment = environment
-        self.authRequired = alwaysRequireAuth
         super.init(nibName: nil, bundle :nil)
         self.title = title
     }
@@ -83,9 +81,5 @@ class BrowserViewController: UIViewController, InterfaceOrientationOverriding, A
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .allButUpsideDown
-    }
-
-    func alwaysRequireAuth() -> Bool {
-        return authRequired
     }
 }

--- a/Source/EnrolledCoursesViewController+Banner.swift
+++ b/Source/EnrolledCoursesViewController+Banner.swift
@@ -37,18 +37,18 @@ extension EnrolledCoursesViewController: BannerViewControllerDelegate {
 
         environment.networkManager.taskForRequest(request) { [weak self] result in
             if let link = result.data?.first {
-                self?.showBanner(with: link, title: nil, requireAuth: true, showNavbar: false)
+                self?.showBanner(with: link, title: nil, showNavbar: false)
             }
         }
     }
 
-    private func showBanner(with link: String, title: String?, requireAuth: Bool, modal: Bool = true, showNavbar: Bool) {
+    private func showBanner(with link: String, title: String?, modal: Bool = true, showNavbar: Bool) {
         guard let topController = UIApplication.shared.topMostController(),
               let URL = URL(string: link) else { return }
-        environment.router?.showBannerViewController(from: topController, url: URL, title: title, delegate: self, alwaysRequireAuth: requireAuth, modal: modal, showNavbar: showNavbar)
+        environment.router?.showBannerViewController(from: topController, url: URL, title: title, delegate: self, modal: modal, showNavbar: showNavbar)
     }
 
-    private func showBrowserViewController(with link: String, title: String? ,requireAuth: Bool) {
+    private func showBrowserViewController(with link: String, title: String?) {
         guard let topController = UIApplication.shared.topMostController(),
               let URL = URL(string: link) else { return }
         environment.router?.showBrowserViewController(from: topController, title: title, url: URL)
@@ -61,14 +61,14 @@ extension EnrolledCoursesViewController: BannerViewControllerDelegate {
         case .continueWithoutDismiss:
             if let screen = screen,
                let navigationURL = navigationURL(for: screen) {
-                showBanner(with: navigationURL, title: nil, requireAuth: authRequired(for: screen), modal: false, showNavbar: true)
+                showBanner(with: navigationURL, title: nil, modal: false, showNavbar: true)
             }
             break
         case .dismiss:
             dismiss(animated: true) { [weak self] in
                 if let screen = screen,
                    let navigationURL = self?.navigationURL(for: screen) {
-                    self?.showBrowserViewController(with: navigationURL, title: self?.title(for: screen), requireAuth: self?.authRequired(for: screen) ?? false)
+                    self?.showBrowserViewController(with: navigationURL, title: self?.title(for: screen))
                 }
             }
             break
@@ -92,15 +92,6 @@ extension EnrolledCoursesViewController: BannerViewControllerDelegate {
             return Strings.ProfileOptions.Deleteaccount.webviewTitle
         default:
             return nil
-        }
-    }
-
-    private func authRequired(for screen: BannerScreen) -> Bool {
-        switch screen {
-        case .deleteAccount:
-            return true
-        default:
-            return false
         }
     }
 }

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -418,8 +418,8 @@ extension OEXRouter {
         controller?.present(ForwardingNavigationController(rootViewController: upgradeDetailController), animated: true, completion: completion)
     }
     
-    func showBrowserViewController(from controller: UIViewController, title: String?,  url: URL, alwaysRequireAuth: Bool = false, completion: (() -> Void)? = nil) {
-        let browserViewController = BrowserViewController(title: title, url: url, environment: environment, alwaysRequireAuth: alwaysRequireAuth)
+    func showBrowserViewController(from controller: UIViewController, title: String?,  url: URL, completion: (() -> Void)? = nil) {
+        let browserViewController = BrowserViewController(title: title, url: url, environment: environment)
         if let controller = controller as? BrowserViewControllerDelegate {
             browserViewController.delegate = controller
         }
@@ -428,8 +428,8 @@ extension OEXRouter {
         controller.present(navController, animated: true, completion: completion)
     }
     
-    func showBannerViewController(from controller: UIViewController, url: URL, title: String?, delegate: BannerViewControllerDelegate? = nil, alwaysRequireAuth: Bool = false, modal: Bool = true, showNavbar: Bool = false) {
-        let bannerController = BannerViewController(url: url, title: title, environment: environment, alwaysRequireAuth: alwaysRequireAuth, showNavbar: showNavbar)
+    func showBannerViewController(from controller: UIViewController, url: URL, title: String?, delegate: BannerViewControllerDelegate? = nil, modal: Bool = true, showNavbar: Bool = false) {
+        let bannerController = BannerViewController(url: url, title: title, environment: environment, showNavbar: showNavbar)
         bannerController.delegate = delegate
         if modal {
             let navController = ForwardingNavigationController(rootViewController: bannerController)

--- a/Source/ProfileOptionsViewController.swift
+++ b/Source/ProfileOptionsViewController.swift
@@ -346,7 +346,7 @@ extension ProfileOptionsViewController: DeleteAccountCellDelegate {
         guard let topController = UIApplication.shared.topMostController(), let URLString = environment.config.deleteAccountURL, let URL = URL(string: URLString) else { return }
 
         environment.analytics.trackEvent(with: AnalyticsDisplayName.ProfileDeleteAccountClicked, name: AnalyticsEventName.ProfileDeleteAccountClicked)
-        environment.router?.showBrowserViewController(from: topController, title: Strings.ProfileOptions.Deleteaccount.webviewTitle, url: URL, alwaysRequireAuth: true)
+        environment.router?.showBrowserViewController(from: topController, title: Strings.ProfileOptions.Deleteaccount.webviewTitle, url: URL)
     }
 }
 

--- a/Source/WebviewCookiesManager.swift
+++ b/Source/WebviewCookiesManager.swift
@@ -1,0 +1,122 @@
+//
+//  WebviewSessionManager.swift
+//  edX
+//
+//  Created by Saeed Bashir on 1/6/22.
+//  Copyright © 2022 edX. All rights reserved.
+//
+
+import Foundation
+
+let WebviewCookiesCreatedNotification = "CookiesCreatedNotification"
+
+enum WebviewCookiesManagerState {
+    case none, creating, created, cookiesSet, failed
+}
+
+// A class that will manage the session and other relevant cookies for AuthenticatedWebViewController
+// This class will be responsbile for making the /oauth2/login/ and manage session cookies
+class WebviewCookiesManager: NSObject {
+
+    // We'll assume that cookies are valid for at least one hour after that
+    // we'll refresh the cookies, the cookies expiration is also being handled in the response of webview loading
+    private let refreshInterval: Double = 60 * 60
+    private var authSessionCookieExpiration: Double = -1
+    private(set) var cookiesState: WebviewCookiesManagerState = .none
+    static let shared = WebviewCookiesManager()
+
+    var cookiesExpired: Bool {
+        return authSessionCookieExpiration < Date().timeIntervalSince1970
+    }
+
+    private override init() {
+        super.init()
+
+        NotificationCenter.default.oex_addObserver(observer: self, name: NSNotification.Name.OEXSessionEnded.rawValue) { (_, observer, _) in
+            observer.clearCookies()
+        }
+    }
+
+    public func createOrUpdateCookies() {
+        clearCookies()
+        cookiesState = .creating
+        let network = OEXRouter.shared().environment.networkManager
+        network.taskForRequest(loginAPI()) { [weak self] result in
+            self?.updateSessionState(state: result.error == nil ? .cookiesSet : .failed)
+        }
+    }
+
+    func clearCookies() {
+        authSessionCookieExpiration = -1
+        cookiesState = .none
+        let storage = HTTPCookieStorage.shared
+        let cookies = storage.cookies
+        for cookie in cookies! {
+            storage.deleteCookie(cookie)
+        }
+    }
+
+    private func parseAndSetCookies(response: HTTPURLResponse) {
+
+        guard let fields = response.allHeaderFields as? [String : String],
+              let url = OEXConfig.shared().apiHostURL()
+        else { return }
+
+        let cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
+
+        for cookie in cookies {
+            var cookieProperties = [HTTPCookiePropertyKey: Any]()
+            cookieProperties[.name] = cookie.name
+            cookieProperties[.value] = cookie.value
+            cookieProperties[.domain] = cookie.domain
+            cookieProperties[.path] = cookie.path
+            cookieProperties[.version] = cookie.version
+            cookieProperties[.expires] = cookie.expiresDate
+
+            if let newCookie = HTTPCookie(properties: cookieProperties) {
+                HTTPCookieStorage.shared.setCookie(newCookie)
+            }
+        }
+    }
+
+    func updateSessionState(state: WebviewCookiesManagerState) {
+        cookiesState = state
+        switch state {
+        case .cookiesSet:
+            authSessionCookieExpiration = Date().addingTimeInterval(refreshInterval).timeIntervalSince1970
+            postCookiesSetNotification(status: true)
+            break
+        case .created:
+            break
+        default:
+            authSessionCookieExpiration = -1
+            postCookiesSetNotification(status: false)
+            clearCookies()  
+            break
+        }
+    }
+
+    private func postCookiesSetNotification(status: Bool) {
+        NotificationCenter.default.post(name: NSNotification.Name(WebviewCookiesCreatedNotification), object: status)
+    }
+
+    private func loginAPI() -> NetworkRequest<()> {
+        let path = "/oauth2/login/"
+
+        return NetworkRequest(
+            method: .POST,
+            path: path,
+            requiresAuth: true,
+            deserializer: .noContent(cookiesDeserializer))
+    }
+
+    private func cookiesDeserializer(response: HTTPURLResponse) -> Result<()> {
+        guard response.httpStatusCode.is2xx else {
+            return Failure(e: NSError(domain: "LoginApiErrorDomain", code: response.statusCode, userInfo: [NSLocalizedDescriptionKey: "unable to get cookies"]))
+        }
+
+        parseAndSetCookies(response: response)
+
+        return Success(v: ())
+    }
+}

--- a/Source/WebviewCookiesManager.swift
+++ b/Source/WebviewCookiesManager.swift
@@ -51,32 +51,18 @@ class WebviewCookiesManager: NSObject {
         cookiesState = .none
         let storage = HTTPCookieStorage.shared
         let cookies = storage.cookies
-        for cookie in cookies! {
+        for cookie in cookies ?? [] {
             storage.deleteCookie(cookie)
         }
     }
 
     private func parseAndSetCookies(response: HTTPURLResponse) {
-
         guard let fields = response.allHeaderFields as? [String : String],
               let url = OEXConfig.shared().apiHostURL()
         else { return }
 
         let cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
-
-        for cookie in cookies {
-            var cookieProperties = [HTTPCookiePropertyKey: Any]()
-            cookieProperties[.name] = cookie.name
-            cookieProperties[.value] = cookie.value
-            cookieProperties[.domain] = cookie.domain
-            cookieProperties[.path] = cookie.path
-            cookieProperties[.version] = cookie.version
-            cookieProperties[.expires] = cookie.expiresDate
-
-            if let newCookie = HTTPCookie(properties: cookieProperties) {
-                HTTPCookieStorage.shared.setCookie(newCookie)
-            }
-        }
+        HTTPCookieStorage.shared.setCookies(cookies, for: url, mainDocumentURL: nil)
     }
 
     func updateSessionState(state: WebviewCookiesManagerState) {

--- a/Source/WebviewCookiesManager.swift
+++ b/Source/WebviewCookiesManager.swift
@@ -11,7 +11,7 @@ import Foundation
 let WebviewCookiesCreatedNotification = "CookiesCreatedNotification"
 
 enum WebviewCookiesManagerState {
-    case none, creating, created, cookiesSet, failed
+    case none, creating, set, created, failed
 }
 
 // A class that will manage the session and other relevant cookies for AuthenticatedWebViewController
@@ -42,7 +42,7 @@ class WebviewCookiesManager: NSObject {
         cookiesState = .creating
         let network = OEXRouter.shared().environment.networkManager
         network.taskForRequest(loginAPI()) { [weak self] result in
-            self?.updateSessionState(state: result.error == nil ? .cookiesSet : .failed)
+            self?.updateSessionState(state: result.error == nil ? .set : .failed)
         }
     }
 
@@ -68,7 +68,7 @@ class WebviewCookiesManager: NSObject {
     func updateSessionState(state: WebviewCookiesManagerState) {
         cookiesState = state
         switch state {
-        case .cookiesSet:
+        case .set:
             authSessionCookieExpiration = Date().addingTimeInterval(refreshInterval).timeIntervalSince1970
             postCookiesSetNotification(status: true)
             break

--- a/Source/WebviewCookiesManager.swift
+++ b/Source/WebviewCookiesManager.swift
@@ -11,7 +11,7 @@ import Foundation
 let WebviewCookiesCreatedNotification = "CookiesCreatedNotification"
 
 enum WebviewCookiesManagerState {
-    case none, creating, set, created, failed
+    case none, creating, sync, created, failed
 }
 
 // A class that will manage the session and other relevant cookies for AuthenticatedWebViewController
@@ -42,7 +42,7 @@ class WebviewCookiesManager: NSObject {
         cookiesState = .creating
         let network = OEXRouter.shared().environment.networkManager
         network.taskForRequest(loginAPI()) { [weak self] result in
-            self?.updateSessionState(state: result.error == nil ? .set : .failed)
+            self?.updateSessionState(state: result.error == nil ? .sync : .failed)
         }
     }
 
@@ -68,7 +68,7 @@ class WebviewCookiesManager: NSObject {
     func updateSessionState(state: WebviewCookiesManagerState) {
         cookiesState = state
         switch state {
-        case .set:
+        case .sync:
             authSessionCookieExpiration = Date().addingTimeInterval(refreshInterval).timeIntervalSince1970
             postCookiesSetNotification(status: true)
             break

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -910,6 +910,7 @@
 		E0A2461D1D5CA6950066C766 /* LogoutApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A2461C1D5CA6950066C766 /* LogoutApi.swift */; };
 		E0A2461F1D5DA12A0066C766 /* AppStoreConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A2461E1D5DA12A0066C766 /* AppStoreConfig.swift */; };
 		E0A246211D5DB3FD0066C766 /* AppUpgradeConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A246201D5DB3FD0066C766 /* AppUpgradeConfigTests.swift */; };
+		E0A948132786A6DE00BE79D9 /* WebviewCookiesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A948122786A6DE00BE79D9 /* WebviewCookiesManager.swift */; };
 		E0AF4E8E1BFB19CC0083753C /* PassthroughView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AF4E8D1BFB19CC0083753C /* PassthroughView.swift */; };
 		E0B4F3621EBB133000D42C11 /* WhatsNewContentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B4F3611EBB133000D42C11 /* WhatsNewContentController.swift */; };
 		E0C6EF971BFF4B9900B315E3 /* UIButton+TintColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C6EF961BFF4B9900B315E3 /* UIButton+TintColor.swift */; };
@@ -2120,6 +2121,7 @@
 		E0A2461C1D5CA6950066C766 /* LogoutApi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogoutApi.swift; sourceTree = SOURCE_ROOT; };
 		E0A2461E1D5DA12A0066C766 /* AppStoreConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStoreConfig.swift; sourceTree = "<group>"; };
 		E0A246201D5DB3FD0066C766 /* AppUpgradeConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppUpgradeConfigTests.swift; sourceTree = "<group>"; };
+		E0A948122786A6DE00BE79D9 /* WebviewCookiesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebviewCookiesManager.swift; sourceTree = "<group>"; };
 		E0AF4E8D1BFB19CC0083753C /* PassthroughView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassthroughView.swift; sourceTree = "<group>"; };
 		E0B4F3611EBB133000D42C11 /* WhatsNewContentController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhatsNewContentController.swift; sourceTree = "<group>"; };
 		E0C6EF961BFF4B9900B315E3 /* UIButton+TintColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+TintColor.swift"; sourceTree = "<group>"; };
@@ -3072,6 +3074,7 @@
 				77503E8D1B287DBF00C47229 /* KeyboardInsetsSource.swift */,
 				7784C68A1B03BA1E00529C7C /* LoadStateViewController.swift */,
 				9EAB5BE81B564C2F00CA9F3C /* ProgressController.swift */,
+				E0A948122786A6DE00BE79D9 /* WebviewCookiesManager.swift */,
 			);
 			name = "Controller Helpers";
 			sourceTree = "<group>";
@@ -5239,6 +5242,7 @@
 				77092C751B42E4C1004AA1A1 /* UIStatusBarStyle+Styles.swift in Sources */,
 				191A002E19405E97004F7902 /* OEXLatestUpdates.m in Sources */,
 				1AFEB1B61BBD5B95004C471D /* ProfilePictureTaker.swift in Sources */,
+				E0A948132786A6DE00BE79D9 /* WebviewCookiesManager.swift in Sources */,
 				B7CCC723209B16B100A66923 /* ConstraintPriorityTarget.swift in Sources */,
 				77E647CE1C90CAB800B6740D /* NSAttributedString+OEXFormatting.m in Sources */,
 				E09B9D6B1D06C9700080BAE0 /* VersionUpgradeInfoController.swift in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-8700](https://openedx.atlassian.net/browse/LEARNER-8700)

Create a webview cookies manager to manage sessions and other relevant cookies for the `AuthenticatedWebViewController`. The new cookies manager will be responsible for making the oauth2/login API call to get the session and other relevant cookies and save the cookies to load the authenticated webview. 

At the moment, there isn’t any cookies manager to manage the cookies, what we are doing is we are loading the URL in the webview and if the server responds with a special error 404 then the webview first does the /oauth2/login request to load session cookies and then reload the initial request again.

The problem with this approach is that if multiple instances of `AuthenticatedWebViewController` are created then there might be a race condition to create session cookies by the different instances of `AuthenticatedWebViewController`.

1. Write a `WebviewCookiesManager` to manage cookies for `AuthenticatedWebViewController`.
2. Remove `AuthenticatedWebViewControllerRequireAuthentication` from the `BannerViewController` to get the benefits of `WebviewCookiesManager`.
3. Remove `AuthenticatedWebViewControllerRequireAuthentication` from the BrowserViewController to get the benefits of `WebviewCookiesManager`.

### How to Test  the PR

Load any URL like my programs URL, delete account URL, block URL, 2U banner URL & `AuthenticatedWebViewController` won't be making any `/oauth2/login` call and instead `WebviewCookiesManager` will be managing all the cookies related stuff.
