### PR TITLE
feat: added translations for all languages after 2U release

### DIFF
--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -281,23 +281,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Resources";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "لقد غُيِّرت المواعيد المقررة لديك لمساعدتك على متابعة التقدم في المسار الصحيح.";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "عرض جميع المواعيد";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Important Dates";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="منجز";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="تجاوز تاريخ الاستلام";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="موعد الاستلام  التالي";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="لم يصدر بعد";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="مسجل فقط";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="اليوم";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -317,73 +317,73 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="لقد غُيِّرت المواعيد لديك بنجاح.";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="تعذر تغيير المواعيد لديك. فيُرجى المحاولة مرة أخرى.";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"=" لقد وضعنا لك، على سبيل الاقتراح، جدولاً ليساعدك على متابعة التقدم في المسار الصحيح.";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="ولا داعي للقلق؛ فهو جدول يتسم بالمرونة بما يُمكِّنك من التعلم على طريقتك الخاصة. فإذا حدث أن تأخرت عن المواعيد المقترحة في هذا الجدول، فباستطاعتك تعديلها لتتابع التقدم في مسارك الصحيح.";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="أنت تقوم بمراجعة هذه الدورة التدريبية ";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="مما يعني أنك غير قادر على المشاركة في الواجبات المقدرة. لإكمال الواجبات المقدرة كجزء من هذه الدورة التدريبية ، يمكنك الترقية اليوم.";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="ترفيع المستوى الآن";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"=" انت تقوم بمراجعة هذه الدورة التدريبية";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="مما يعني انك غير قادر ان تشارك في الواجبات المقدرة. يبدو انك فاتتك بعض المواعيد المهمة بناء على جدولنا .لتكمل الواجبات المقدرة كجزء من هذه الدورة ونقل واجبات الماضي الي المستقبل، يمكنك الترقية اليوم";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"=" يبدو انك فاتتك بعض المراعيد المهمة بناء على جدولنا المقترح";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="لتبقى نفسك على المسار الصحيح، يمكنك ترقية جدولك و نقل واجبات الماضي الي المستقبل. لا تقلق لن تخسر اي تقدم فعلته عندما تنقل التواريخ المحددة";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="تغيير المواعيد المقررة";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="جدول الدورة";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="مزامنة مع التقويم";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="مزامنة جميع المواعيد النهائية وتواريخ الاستحقاق الخاصة بهذه الدورة التدريبية تلقائيًا مع التقويم الخاص بك.";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="إضافة التقويم \"{calendar_name}\"";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"=">إزالة التقويم \"{calendar_name}\"";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"=">هل ترغب في إضافة تقويم {platform_name} \"{calendar_name}\"؟ \n  يمكنك تحرير أو إزالة تقويم المقرر الدراسي الخاص بك في أي وقت في \"التقويم\" أو \"الإعدادات\".";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="هل ترغب في إزالة التقويم {platform_name} \"{calendar_name}\"";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "لقد أُضِيفت الدورة \"{calendar_name}\" إلى التقويم في هاتفك.";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="تمت إضافة تقويم المقرر الدراسي الخاص بك.";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="لقد تم حذف تقويم دورتك";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="تم تحديث تقويم المقرر الدراسي الخاص بك.";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="تقويم الدورة التدريبية الخاص بك قديم";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="تم تغيير تواريخ الدورة التدريبية الخاصة بك ولم يعد تقويم الدورة التدريبية محدثًا مع جدولك الجديد.";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="إزالة تقوم الدورة التدريبية";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="مزامنة التقويم...";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="اكتمل ترفيع المستوى";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"=">نشكرك على معاملة الشراء هذه. وبإمكانك المتابعة من حيث توقفت، والاستمتاع بالاطلاع التام على محتوى الدورة لديك.";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -459,13 +459,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="هذا المساق لا يتضمن أي مقاطع فيديو";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} س";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} ساعات";
 /* 1 minute */
-"COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
+"COURSE_VIDEO_MINUTES##{one}" = "{minutes} دقيقة";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} دقائق";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "هذا المكوّن التفاعلي غير متوفر بعد على الأجهزة المحمولة\n\nاستكشف أجزاء المساق الأخرى أو استعرض هذا المكوّن باستخدام الويب.";
 /* Message shown when attempting to display content not available on the app, from dates tab */
@@ -569,7 +569,7 @@
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="أنشىء مشاركة جديدة";
 /* Chrome cast message */
-"CHROMECAST_MESSAGE"="Video is casting to remote device";
+"CHROMECAST_MESSAGE"="جارٍ بث الفيديو على جهاز بعيد";
 /* Button text to initiate or confirm deletion */
 "DELETE"="حذف";
 /* Discussion used in the segmented control Creating a new post */
@@ -659,9 +659,9 @@
 /* Endorsed text */
 "ENDORSED" = "مصادق عليه";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="قد يعمل هذا الجزء من الدورة بشكل أفضل في متصفح الويب";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="فتح في المتصفح";
 /* Facebook login method */
 "FACEBOOK"="فيسبوك";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -809,7 +809,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "تعديل الصفحة الشخصيّة";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="معلومات ملفك الشخصي مرئية لك فقط. يظهر اسم المستخدم الخاص بك فقط للآخرين على {platform_name}.";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "تعديل الصفحة الشخصيّة";
 /* Accessibility hint for country field in user profile */
@@ -941,17 +941,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "هذا الإعداد لجميع تنزيلات الفيديو في تطبيق {platform_name}.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "جودة تنزيل الفيديو";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "تلقائى (موصى به)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360 بكسل (أصغر حجم للملف)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720 بكسل (أفضل جودة)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="تسجيل الدخول";
 /* Message shown while user waits for response to a sign in request */
@@ -1027,37 +1027,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "الملف الشخصي";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "ترقية {course_name}";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "دولارً {price} قم بالتحديث  الآن مقابل";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "كيفية فتح الواجبات المقدرة";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "الواجبات المقدرة مؤمنة";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "قم بالترقية للوصول إلى الميزات المقفلة مثل هذه الميزة وتحقيق أقصى استفادة من الدورة التدريبية الخاصة بك";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="قم بالترقية للوصول إلى المزيد من الميزات";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="تعلم اكثر";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="تعرف على المزيد حول الميزات المقفلة";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="احصل على شهادة إتمام موثقة لعرضها في سيرتك الذاتية";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="افتح الوصول إلى جميع أنشطة المقرر الدراسي ، بما في ذلك الواجبات المقدرة";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="الوصول الكامل إلى محتوى الدورة ومواد الدورة التدريبية حتى بعد انتهاء الدورة";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="اظهر المزيد";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="اظهر اقل";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/ar.lproj/ProfileOptions.strings
+++ b/Source/ar.lproj/ProfileOptions.strings
@@ -7,7 +7,7 @@
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "المعلومات الشخصية";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "البريد الإلكتروني:{email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "البريد الإلكتروني: {email}";
 /* Settings user profile username */
 "PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "اسم المستخدم: {username}";
 /* Settings message for profile */

--- a/Source/ar.lproj/ProfileOptions.strings
+++ b/Source/ar.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "اعدادات الفيديو";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "التحميل من خلال الـ Wi-Fi فقط";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "تحميل المواد والبيانات عندما يكون الجهاز متصلاً بالـ Wi-Fi فقط.";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "المعلومات الشخصية";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "البريد الإلكتروني:{email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "اسم المستخدم: {username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "تشارك حاليًا جزء محدود من معلومات صفحتك الشخصية.";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "المشتريات";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "استعادة المشتريات";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "سجّل الدخول إلى متجر App لاستعادة الوصول إلى الدورات التدريبية التي دفعتها سابقًا للترقية";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "مساعدة";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "هل تتطلع إلى تقديم طلب ميزة أو تزويدنا ببعض التعليقات على تطبيقنا؟";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "أرسل بريدًا إلكترونيًا إلى فريق الدعم";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "تلفى الدعم";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "للحصول على مزيد من المساعدة ومعرفة كيفية استخدام تطبيق الجوال {platform_name} ، تفضل بزيارة الأسئلة الشائعة.";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "مشاهدة التعليمات";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "خروج";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "احذف حسابي";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "تتبع التعليمات في الشاشة التالية لتحذف حسابك و كل البيانات المتعلقة";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "احذف حسابك";

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -265,7 +265,7 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Ressourcen";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Ihre Fälligkeitstermine wurden erfolgreich verschoben, damit Sie Ihren Zeitplan einhalten können.    ";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Ihre Fälligkeitstermine wurden erfolgreich verschoben, damit Sie Ihren Zeitplan einhalten können.";
 /* Course Dates navigate to Dates screen*/
 "COURSEDATES.VIEW_ALL_DATES" = "Alle Termine anzeigen";
 /* Title of course important dates screen */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -971,7 +971,7 @@
 /* Value prop upgrade button text with price */
 "VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade jetzt durchführen für {price} US-Dollar";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= ">So entsperren Sie benotete Aufgaben";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "So entsperren Sie benotete Aufgaben";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
@@ -985,7 +985,7 @@
 /* Value prop detail view title learn more*/
 "VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Erfahren Sie mehr über gesperrte Funktionen";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"=">Verdienen Sie ein verifiziertes Abschlusszertifikat, das Sie in Ihrem Lebenslauf präsentieren können";
+"VALUE_PROP.INFO_MESSAGE_1"="Verdienen Sie ein verifiziertes Abschlusszertifikat, das Sie in Ihrem Lebenslauf präsentieren können";
 /* Value prop information message number two*/
 "VALUE_PROP.INFO_MESSAGE_2"="Schalten Sie den Zugriff auf alle Kursaktivitäten frei, einschließlich benoteter Aufgaben";
 /* Value prop information message number three*/

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -265,23 +265,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Ressourcen";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Ihre Fälligkeitstermine wurden erfolgreich verschoben, damit Sie Ihren Zeitplan einhalten können.    ";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "Alle Termine anzeigen";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Wichtige Daten";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="Abgeschlossen";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="Überfällig";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="Als nächstes fällig";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="Noch nicht veröffentlicht";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="Nur für verifizierte Benutzer";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="Heute";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -301,73 +301,73 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Ihre Termine wurden erfolgreich verschoben.";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Ihre Termine konnten nicht verschoben werden. Bitte versuchen Sie es erneut.";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="Wir haben einen vorgeschlagenen Zeitplan erstellt, um Ihnen zu helfen, Ihre Planung einzuhalten. ";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="Aber keine Sorge – er ist flexibel, sodass Sie in Ihrem eigenen Tempo lernen können. Sollten Sie mit unseren Terminvorschlägen in Verzug geraten, können sie Sie anpassen, um Ihren Zeitplan einzuhalten.";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="Sie sind Gasthörer für diesen Kurs, ";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="was bedeutet, dass Sie nicht an benoteten Aufgaben teilnehmen können. Um benotete Aufgaben im Rahmen dieses Kurses abzuschließen, können Sie noch heute ein Upgrade durchführen.";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Jetzt Upgrade durchführen";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="Sie sind Gasthörer für diesen Kurs, ";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="was bedeutet, dass Sie nicht an benoteten Aufgaben teilnehmen können. Es sieht so aus, als ob Sie einige wichtige Fristen verpasst haben, basierend auf unserem vorgeschlagenen Zeitplan. Um benotete Aufgaben im Rahmen dieses Kurses abzuschließen und überfällige Aufgaben in die Zukunft zu verschieben, können Sie noch heute ein Upgrade durchführen.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Es sieht so aus, als ob Sie einige wichtige, auf unserem vorgeschlagenen Zeitplan basierende Fristen verpasst haben. ";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Um den Zeitplan einzuhalten, können Sie ihn aktualisieren und die überfälligen Aufgaben in die Zukunft verschieben. Keine Sorge – Sie verlieren keinen Ihrer Fortschritte, wenn Sie Ihre Fälligkeitstermine verschieben.";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Fälligkeitstermine verschieben";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="Kursplan";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="Mit Kalender synchronisieren";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Synchronisieren Sie automatisch alle Fristen und Fälligkeitstermine für diesen Kurs mit Ihrem Kalender.";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="Kalender \"{calendar_name}\" hinzufügen";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="Kalender \"{calendar_name}\" entfernen";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"="Möchten Sie den {platform_name}-Kalender \"{calendar_name}\" hinzufügen? \n Sie können Ihren Kurskalender jederzeit im Kalender oder in den Einstellungen bearbeiten oder entfernen.";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Möchten Sie den {platform_name}-Kalender \"{calendar_name}\" entfernen?";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" wurde dem Kalender Ihres Mobiltelefons hinzugefügt.";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="Ihr Kurskalender wurde hinzugefügt.";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Ihr Kurskalender wurde entfernt.";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Ihr Kurskalender wurde aktualisiert.";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Ihr Kurskalender ist veraltet";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Ihre Kurstermine wurden verschoben und Ihr Kurskalender entspricht nicht mehr Ihrem neuen Kursplan.";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Kurskalender entfernen";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Kalender wird synchronisiert ...";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade abgeschlossen";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Danke für Ihren Einkauf. Sie können genau dort weitermachen, wo Sie aufgehört haben, und vollen Zugriff auf Ihre Kursinhalte haben.";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -431,13 +431,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="Dieser Kurs beinhaltet keine Videos";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} Stunde";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} Stunden";
 /* 1 minute */
-"COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
+"COURSE_VIDEO_MINUTES##{one}" = "{minutes} Min";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} Min";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "Diese Interaktive Komponente ist derzeit nicht für Mobile Endgeräte verfügbar.\n\nErkunden Sie andere Komponenten dieses Kurses oder nutzen Sie den Browser.";
 /* Message shown when attempting to display content not available on the app, from dates tab */
@@ -611,9 +611,9 @@
 /* Endorsed text */
 "ENDORSED" = "Bestätigt";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="Dieser Teil des Kurses funktioniert möglicherweise am besten in einem Webbrowser.";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Im Browser öffnen";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -761,7 +761,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "Profil bearbeiten";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="Ihre Profilinformationen sind nur für Sie sichtbar. Nur Ihr Benutzername ist für andere auf {platform_name} sichtbar.";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "Profil bearbeiten";
 /* Accessibility hint for country field in user profile */
@@ -881,17 +881,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "Diese Einstellung gilt für alle Video-Downloads in der {platform_name}-App.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video-Download-Qualität";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Automatisch (Empfohlen)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Kleinste Dateigröße)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Beste Qualität)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="Anmelden";
 /* Message shown while user waits for response to a sign in request */
@@ -967,37 +967,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "Profil";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "Upgrade für {course_name} durchführen";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade jetzt durchführen für {price} US-Dollar";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= ">So entsperren Sie benotete Aufgaben";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Benotete Aufgaben sind gesperrt";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Führen Sie ein Upgrade durch, um Zugriff auf gesperrte Funktionen wie diese zu erhalten und Ihren Kurs optimal zu nutzen";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="Führen Sie ein Upgrade durch, um auf weitere Funktionen zuzugreifen";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Weitere Informationen";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Erfahren Sie mehr über gesperrte Funktionen";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"=">Verdienen Sie ein verifiziertes Abschlusszertifikat, das Sie in Ihrem Lebenslauf präsentieren können";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="Schalten Sie den Zugriff auf alle Kursaktivitäten frei, einschließlich benoteter Aufgaben";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="Voller Zugriff auf Kursinhalte und Kursmaterial auch nach Kursende";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="Mehr anzeigen";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="Weniger anzeigen";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/de.lproj/ProfileOptions.strings
+++ b/Source/de.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "Videoeinstellungen";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Download nur über Wi-Fi";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Nur herunterladen, wenn WiFi aktiviert ist";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "Persönliche Informationen";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "E-Mail: {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Benutzername: {username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "Ihr Profil ist nur teilweise sichtbar für andere Nutzere";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "Käufe";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "Einkäufe wiederherstellen";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Melden Sie sich im App Store an, um den Zugriff auf Kurse wiederherzustellen, für die Sie zuvor ein Upgrade bezahlt haben";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "Hilfe";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Möchten Sie eine Funktionsanfrage stellen oder uns Feedback zu unserer App geben?";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "E-Mail an das Support-Team senden";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Unterstützung holen";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "Um weitere Hilfe zu erhalten und zu erfahren, wie Sie die mobile App {platform_name} verwenden, besuchen Sie unsere häufig gestellten Fragen.";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "Häufig gestellte Fragen anzeigen";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Abmelden";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Konto löschen";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Befolgen Sie die Anweisungen auf dem nächsten Bildschirm, um Ihr Konto und alle zugehörigen Daten zu löschen.";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Konto löschen";

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -611,7 +611,7 @@
 /* Endorsed text */
 "ENDORSED" = "Endorsed";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of the course may work best in a web browser.";
 /*Open in external browser banner underline text*/
 "OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
@@ -986,8 +986,6 @@
 "VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
 /* Value prop detail view title*/
 "VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
 /* Value prop information message number one*/
 "VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
 /* Value prop information message number two*/

--- a/Source/en.lproj/ProfileOptions.strings
+++ b/Source/en.lproj/ProfileOptions.strings
@@ -6,14 +6,6 @@
 "PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */
 "PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
 /* Settings user profile username */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -265,23 +265,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Ressources";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Vos dates d'échéance ont été déplacées avec succès pour vous aider à rester sur la bonne voie.";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "Voir toutes les dates";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Dates importantes";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="Terminé";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="En retard";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="À rendre ensuite";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="Pas encore lancé";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="Utilisateurs vérifiés uniquement";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="Aujourd'hui";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -301,73 +301,73 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Vos dates ont été changées avec succès.";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Vos dates n'ont pas pu être modifiées. Veuillez réessayer.";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="Nous vous suggérons un programme prédéfini pour vous aider à rester sur la bonne voie. ";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="Mais ne vous inquiétez pas : il est flexible et vous pouvez donc apprendre à votre rythme. Si vous prenez du retard par rapport aux dates suggérées, vous pouvez les ajuster afin de rester sur la bonne voie.";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="Vous suivez ce cours en tant qu\'auditeur libre, ";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="ce qui signifie que vous ne pouvez pas participer aux devoirs notés. Pour faire les devoirs notés dans le cadre de ce cours, vous pouvez mettre à niveau votre inscription dès aujourd'hui.";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Mettre à jour maintenant";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="Vous suivez ce cours en tant qu'auditeur libre, ";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="ce qui signifie que vous ne pouvez pas participer aux devoirs notés. Il semblerait que vous ayez manqué des échéances importantes de notre programme suggéré. Pour faire les devoirs notés dans le cadre de ce cours et pouvoir rendre les devoirs passés un peu plus tard, vous pouvez mettre à niveau votre inscription dès aujourd'hui.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Il semblerait que vous ayez manqué des échéances importantes de notre programme suggéré. ";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Pour rester sur la bonne voie, vous pouvez mettre à jour ce programme et rendre les devoirs passés un peu plus tard. Ne vous inquiétez pas : en modifiant les échéances, vous ne perdrez pas les progrès que vous avez faits.";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Déplacer les dates d'échéances";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="Programme du cours";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="Synchroniser au calendrier";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Synchronisez automatiquement les échéances et dates importantes à votre calendrier.";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="Ajouter l'agenda « {calendar_name} »";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="Retirer le calendrier \"{calendar_name}\"";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"="Voulez-vous ajouter l'agenda {platform_name} « {calendar_name} » ? \n Vous pouvez supprimer ou modifier votre agenda de cours à tout moment dans Agenda ou dans Paramètres.";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Voulez-vous supprimer l'agenda {platform_name} « {calendar_name} » ?";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "« {calendar_name} » a été ajouté à l'agenda de votre téléphone.";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="Le calendrier de votre cours a été ajouté.";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Votre calendrier de cours a été enlevé.";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Le calendrier de votre cours a été mis à jour.";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Le calendrier de votre cours n\'est pas à jour";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Les dates de vos cours ont été modifiées et votre agenda de cours ne correspond plus à votre nouveau programme.";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Supprimer l'agenda des cours";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Synchronisation de l'agenda…";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Mise à niveau effectuée";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Merci pour votre achat. Vous pouvez reprendre là où vous vous étiez arrêtés et profiter d\'un accès complet au contenu de cours.";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -431,13 +431,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="Ce cours ne contient aucune vidéo";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} heure";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} heures";
 /* 1 minute */
 "COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} min";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "Ce composant n'est pas encore disponible sur mobile. \n\nExplorer d'autres parties du cours ou le voir sur le web.";
 /* Message shown when attempting to display content not available on the app, from dates tab */
@@ -611,9 +611,9 @@
 /* Endorsed text */
 "ENDORSED" = "Voté";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="Cette partie du cours pourrait mieux fonctionner dans un navigateur web.";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Ouvrir dans le navigateur";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -761,7 +761,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "Modifier le profil";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="Les informations sur votre profil ne sont visibles que par vous. Seul votre nom d'utilisateur est visible par les autres sur {platform_name}.";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "Modifier le profil";
 /* Accessibility hint for country field in user profile */
@@ -881,17 +881,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "Ce paramètre concerne tous les téléchargements vidéo dans l'application {platform_name}.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Qualité de téléchargement vidéo";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommandé)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (plus petite taille de fichier)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Meilleure qualité)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="Connexion";
 /* Message shown while user waits for response to a sign in request */
@@ -967,37 +967,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "Profil";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "Mettre à niveau {course_name}";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "Mettre à niveau pour {price} $";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "Comment déverrouiller les devoirs notés";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Les devoirs notés sont verrouillés";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Mettez à niveau votre inscription pour accéder aux fonctionnalités verrouillées comme celle-ci et ainsi tirer le maximum de vos cours";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="Mettez à niveau votre inscription pour accéder à davantage de fonctionnalités";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="En savoir plus";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="En savoir plus sur les fonctionnalités verrouillées";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="Obtenez un certificat d'achèvement vérifié à ajouter à votre CV";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="Débloquez l'accès à toutes les activités du cours, y compris les devoirs notés";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="Accès complet au contenu et aux supports de cours, même après la fin du cours";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="Montrer plus";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="Montrer moins";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/fr.lproj/ProfileOptions.strings
+++ b/Source/fr.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "Paramètres vidéo";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Téléchargement uniquement disponible en Wi-Fi";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Télécharger les données uniquement lorsque le Wi-Fi est activé";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "Informations personnelles";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "E-mail : {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Nom d'utilisateur: {username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "Vous partagez votre profil limite";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "Achats";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restaurer les achats";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Connectez-vous au App Store pour restaurer l\'accès aux cours que vous avez payés";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "Aide";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Vous souhaitez faire une demande de fonctionnalité ou nous partager votre impression sur notre appli ?";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Envoyer un e-mail à l'équipe support";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Obtenir de l'aide";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "Pour obtenir plus d\'aide et apprendre à utiliser l'application mobile {platform_name}, visitez notre foire aux questions.";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "Voir la FAQ";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Se déconnecter";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Supprimer le compte";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Suivez les instructions sur l'écran suivant pour supprimer votre compte et toutes les données associées.";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Supprimer votre compte";

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -273,23 +273,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="משאבים";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "תאריכי היעד שלך הועברו בהצלחה כדי לשמור אותך על המסלול.";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "צפה בכל התאריכים";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="תאריכים חשובים";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="הושלם";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="עבר מועד";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="למועד הבא";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="עדיין לא שוחררו";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="מאומת בלבד";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="היום";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -309,73 +309,73 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="התאריכים שלך הועברו בהצלחה.";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="לא ניתן היה לשנות את התאריכים שלך. אנא נסה שוב בפעם אחרת.";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="בנינו לוח זמנים מוצע כדי לעזור לך להישאר על המסלול.";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="אבל אל דאגה - זה עדיין גמיש כך שתוכל ללמוד בקצב שלך. אם במקרה תיקלע לפיגור בתאריכים המוצעים שלנו, תוכל להתאים אותם כדי לשמור על עצמך על המסלול.";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="אתה מבקר את הקורס הזה, ";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="מה שאומר שאינך יכול להשתתף במטלות מדורגות. כדי להשלים מטלות מדורגות במסגרת קורס זה, תוכל לשדרג עוד היום.";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="שדרג עכשיו";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="אתה מבקר את הקורס הזה, ";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="מה שאומר שאינך יכול להשתתף במטלות מדורגות. נראה שהחמצת כמה מועדים חשובים בהתבסס על לוח הזמנים המוצע שלנו. כדי להשלים מטלות מדורגות כחלק מהקורס הזה ולהעביר את המטלות שנקבעו בעבר אל העתיד, אתה יכול לשדרג היום.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="נראה שהחמצת כמה מועדים חשובים בהתבסס על לוח הזמנים המוצע שלנו. ";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="כדי לשמור על עצמכם על המסלול, תוכלו לעדכן את לוח הזמנים הזה ולהעביר את ההקצאות שהוגשו לעתיד. אל דאגה - לא תאבד שום התקדמות שהשגת כאשר תשנה את תאריכי היעד שלך.";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="תאריכי יעד של משמרת";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="לוח זמנים של הקורס";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="סנכרון ללוח שנה";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="סנכרן אוטומטית את כל המועדים והתאריכים של קורס זה עם היומן שלך.";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"=">הוסף יומן \"{calendar_name}\"";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="הסר את היומן \"{calendar_name}\"";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"=">האם תרצה להוסיף את לוח השנה של {platform_name} \"{calendar_name}\"? \n אתה יכול לערוך או להסיר את יומן הקורס שלך בכל עת בלוח השנה או בהגדרות.";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="האם תרצה להסיר את לוח השנה של {platform_name} \"{calendar_name}\"?";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" נוסף ללוח השנה של הטלפון שלך.";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="יומן הקורס שלך נוסף.";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="יומן הקורס שלך הוסר.";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="יומן הקורס שלך עודכן.";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="לוח השנה של הקורס שלך כבר לא מעודכן";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="תאריכי הקורסים שלך הועברו ויומן הקורס שלך אינו מעודכן עוד בלוח הזמנים החדש שלך.";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="הסר לוח שנה של הקורס";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="מסנכרן את היומן...";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="השדרוג הושלם";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="תודה על רכישתך. אתה יכול להמשיך מאיפה שהפסקת וליהנות מגישה מלאה לתוכן הקורס שלך.";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -445,13 +445,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="קורס זה אינו כולל קבצי וידאו";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} שָׁעָה";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} שעה (ות";
 /* 1 minute */
-"COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
+"COURSE_VIDEO_MINUTES##{one}" = "{minutes} מ";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} דקות";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "רכיב אינטראקטיבי זה אינו זמין עדיין בגרסת המובייל.\n\nגלו חלקים אחרים בבקורס זה או צפו ברכיב זה ברשת.";
 /* Message shown when there is no course dates */
@@ -545,7 +545,7 @@
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="צרו פוסט חדש";
 /* Chrome cast message */
-"CHROMECAST_MESSAGE"="Video is casting to remote device";
+"CHROMECAST_MESSAGE"="הסרטון משודר אל התקן מרוחק";
 /* Button text to initiate or confirm deletion */
 "DELETE"="מחק";
 /* Discussion used in the segmented control Creating a new post */
@@ -631,9 +631,9 @@
 /* Endorsed text */
 "ENDORSED" = "התקבל";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="חלק זה של הקורס עשוי לעבוד בצורה הטובה ביותר בדפדפן אינטרנט.";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="פתוח בדפדפן";
 /* Facebook login method */
 "FACEBOOK"="פייסבוק";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -779,7 +779,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "ערוך פרופיל";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="פרטי הפרופיל שלך גלויים רק לך. רק שם המשתמש שלך גלוי לאחרים ב-{platform_name}.";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "ערוך פרופיל";
 /* Accessibility hint for country field in user profile */
@@ -905,17 +905,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "הגדרה זו מיועדת לכל הורדות הווידאו באפליקציית {platform_name}.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "איכות הורדת וידאו";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "אוטומטי (מומלץ)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (גודל הקובץ הקטן ביותר)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (איכות מקסימלית)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="היכנס";
 /* Message shown while user waits for response to a sign in request */
@@ -991,37 +991,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "פרופיל";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "שדרג את {course_name}";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "${price} שדרג עכשיו תמורת";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "כיצד לפתוח מטלות מדורגות";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "מטלות עם ציון ננעלות";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "שדרג כדי לקבל גישה מלאה לתכונות נעולות כמו זה ולהפיק את המרב מהקורס שלך";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="שדרג כדי לגשת לתכונות נוספות";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="למד עוד";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="למידע נוסף על תכונות נעולות";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="קבל תעודת סיום מאומתת כדי להציג בקורות החיים שלך בבקשה";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="בטל את הנעילה של גישה לכל פעילויות הקורס, כולל אותן מטלות מדורגות";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="ליהנות מגישה מלאה לתכני הקורס ולחומר הקורס גם לאחר סיום הקורס";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="להראות יותר";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="הראי פחות";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/he.lproj/ProfileOptions.strings
+++ b/Source/he.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "הגדרות וידיאו";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "הורדה רק בWi-Fi";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "הורד תוכן רק כאשר Wi-Fi מחובר";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "מידע אישי";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "אימייל: {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "שם משתמש: {username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "כעת אתם משתפים פרופיל מוגבל.e";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "רכישות";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "לשחזר רכישות";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "היכנס לחנות App כדי לשחזר גישה לקורסים ששילמת בעבר כדי לשדרג";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "עֶזרָה";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "מחפש להגיש בקשה או לתת לנו משוב על האפליקציה שלנו?";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "שלח אימייל לצוות התמיכה";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "קבל תמיכה";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "כדי לקבל עזרה וללמוד כיצד להשתמש באפליקציית {platform_name} לנייד, בקר בשאלות הנפוצות שלנו.";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "הצג שאלות נפוצות";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "התנתק";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "מחק חשבון";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "עקוב אחר ההוראות במסך הבא כדי למחוק את חשבונך ואת כל הנתונים הקשורים.";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "תמחק את החשבון שלך";

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -261,23 +261,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Resources";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "締め切り日を移動しました。この調子で学習を続けましょう。";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "すべての日付を見る";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Important Dates";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="完了";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="期限切れ";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="まもなく期限";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="リリース待ち";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="課金ユーザーのみ";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"=">今日";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -297,73 +297,75 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="日付を移動しました。";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="日付を移動できませんでした。もう一度お試しください。";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="スムーズに学習を進められるよう、推奨スケジュールをご用意しています。";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="忙しい方も心配無用。自分のペースに合わせて柔軟に学習できるので、万が一予定より遅れても その都度、調整が可能です。";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="あなたはこのクラスを聴講しています。";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="採点対象の課題には参加できません。このコースで採点対象の課題を完了するには、アップグレードしてください。";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="今すぐアップグレード";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="あなたはこのクラスを聴講しています。";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="採点対象の課題には参加できません。推奨スケジュールにある重要な期限が守られなかったようです。このコースで採点対象の課題を完了し、過去の期限付き課題を未来日付に移動させるには、アップグレードしてください。";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="推奨スケジュールにある重要な期限が守られなかったようです。";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="このスケジュールを更新し、過去の課題を未来日付に移動させることで、学習を計画通りに進めることができます。期限をずらしてもこれまでの進捗が失われることはありませんので、ご安心ください。";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="期限を移動";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="コーススケジュール";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.COURSE_SCHEDULE"="Lịch biểu khóa học";
+/* Course Dates Sync To Calendar */
+"COURSEDATES.SYNC_TO_CALENDAR"="カレンダーに同期";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="このコースのすべての期限と締め切り日をカレンダーに自動で同期します。";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="カレンダー \"{calendar_name}\" を追加";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="カレンダー \"{calendar_name}\" を削除";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"="{platform_name}のカレンダー \"{calendar_name}\" を追加しますか？\n コースカレンダーは、カレンダーまたは設定でいつでも編集・削除できます。";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="{platform_name}のカレンダー \"{calendar_name}\" を削除しますか？";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "携帯電話のカレンダーに \"{calendar_name}\" を追加しました。";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="コースカレンダーを追加しました。";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="コースカレンダーを削除しました。";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="コースカレンダーを更新しました。";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="コースカレンダーが古くなっています";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="コースの日付が移動されました。コースカレンダーが新しいスケジュールと連携していません。";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="講座カレンダーを削除";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="カレンダーを同期しています...";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="アップグレードが完了しました";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="ご購入いただきありがとうございます。前回進んだところからすぐにコースを再開し、すべてのコンテンツにアクセスできます。";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -424,13 +426,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="この講座は動画がありません。";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} 時間";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} 時間";
 /* 1 minute */
-"COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
+"COURSE_VIDEO_MINUTES##{one}" = "{minutes} 分";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} 分";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "この内容はモバイルでは使えません。\n\n他の内容を見るか、ウェブ上でこの内容をご覧ください。";
 /* Message shown when attempting to display content not available on the app, from dates tab */
@@ -519,7 +521,7 @@
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="新規投稿を作成する";
 /* Chrome cast message */
-"CHROMECAST_MESSAGE"="Video is casting to remote device";
+"CHROMECAST_MESSAGE"="動画をリモートデバイスにキャストしています";
 /* Button text to initiate or confirm deletion */
 "DELETE"="削除";
 /* Discussion used in the segmented control Creating a new post */
@@ -599,9 +601,9 @@
 /* Endorsed text */
 "ENDORSED" = "いいね！";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="このコースコンテンツの閲覧には、Webブラウザの利用を推奨します。";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="ブラウザで開";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -749,7 +751,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "プロフィールを編集";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="プロフィール情報はあなただけが閲覧できます。{platform_name}の他のユーザーにはあなたのユーザー名のみが表示されます。";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "プロフィールを編集";
 /* Accessibility hint for country field in user profile */
@@ -866,17 +868,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "この設定は、{platform_name}アプリ内のすべての動画ダウンロードに適用されます。";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "動画のダウンロード品質";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "自動 (推奨)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (最小ファイルサイズ)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (最高品質)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="サインイン";
 /* Message shown while user waits for response to a sign in request */
@@ -952,37 +954,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "Profile";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "{course_name}をアップグレード";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "${price}で今すぐアップグレード";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "採点対象課題のロックを解除する方法";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "採点対象の課題がロックされています";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "アップグレードしてロックされた機能にアクセスし、コースを最大限に活用しましょう";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="アップグレードしてより多くの機能にアクセス";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="詳細はこちら";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="制限付き機能についての詳細";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="完了したコースの認定証を取得して、履歴書に表示させましょう";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="採点対象の課題を含む、すべてのコースアクティビティへのアクセスを入手";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="コース終了後でもコース内のすべてのコンテンツや資料を閲覧できます";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="もっと表示";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="表示を隠す";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -868,7 +868,7 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "この設定は、{platform_name}アプリ内のすべての動画ダウンロードに適用されます。";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "この設定は、{platform_name} アプリ内のすべての動画ダウンロードに適用されます。";
 /* Settigs title for Video Download Quality */
 "VIDEO_DOWNLOAD_QUALITY_TITLE" = "動画のダウンロード品質";
 /* Settigs message for Video Download Quality Auto */

--- a/Source/ja.lproj/ProfileOptions.strings
+++ b/Source/ja.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "動画設定";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wi-Fi 使用ダウンロード";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Wi-Fi がオンになっているときだけダウンロード";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "個人情報";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = ">メールアドレス: {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "ユーザー名：{username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "現在、限定プロフィールを公開していますe";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "購入";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "購入内容を復元";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "App ストアにサインインして、過去に有料でアップグレードしたコースへのアクセスを復元します";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "ヘルプ";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "機能リクエストまたはアプリのフィードバックを送信しませんか？";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "サポートチームにメールを送信";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "サポートを利用";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "{platform_name}モバイルアプリのヘルプや使い方の詳細は、よくある質問をご覧ください。";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "よくある質問を見る";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "サインアウト";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "アカウントを削除";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "次の画面の指示に従って、アカウントおよびすべての関連するデータを削除します。";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "アカウントを削除";

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -265,23 +265,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Recursos";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Suas datas foram alteradas com sucesso para te ajudar a mantê-lo no controle do tempo.";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "Ver datas";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Datas Importantes";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="Concluído";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="Em atraso";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="Próximo do vencimento";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="Ainda não liberado";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="Apenas verificado";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="Hoje";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -301,73 +301,74 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Suas datas foram alteradas.";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Não foi possível alterar suas datas. Tente novamente.";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="Fizemos uma programação como sugestão para te ajudar a manter o ritmo. ";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="Mas não se preocupe, ela é flexível, assim você pode aprender no seu próprio ritmo.
+Se você não conseguir acompanhar tudo nas datas sugeridas, você poderá ajustá-las de forma que seja melhor para você.";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="Você está participando deste curso, ";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="o que significa que você não pode participar em avaliações. Para completar avaliações como uma parte deste curso, faça o upgrade hoje.";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Fazer o upgrade agora";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="Você está participando deste curso, ";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="o que significa que você não pode participar em avaliações. Para completar avaliações como uma parte deste curso, faça o upgrade hoje. Parece que você perdeu alguns prazos importantes baseados em nossa programação sugerida. Para completar avaliações como parte deste curso e adiar tarefas já atrasadas, faça o upgrade hoje.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Parece que você perdeu alguns prazos importantes baseados em nossa programação sugerida. ";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Para se ficar em dia, você pode atualizar esta programação e adiar as tarefas já atrasadas. Não se preocupe – você não perderá o progresso já feito.";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Alterar datas de entrega";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="Programação do Curso";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="Sincronize com o calendário";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Sincronizar de forma automática com seu calendário, todos os prazos e datas previstas para este curso.";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="Adicionar Calendário \"{calendar_name}\"";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remover Calendar \"{calendar_name}\"";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.calendar_name"="Você deseja adicionar o calendário \"{calendar_name}\" do {platform_name}? \n Você pode editar ou remover o calendário do seu curso a qualquer momento em \"Calendário\" ou \"Configurações\".";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Você deseja remover o calendário \"{calendar_name}\" do {platform_name}?";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "O curso \"{calendar_name}\" foi adicionado ao calendário do seu telefone.";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="Seu calendário do curso foi adicionado.";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="O calendário do seu curso foi removido";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="O calendário do seu curso foi atualizado";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="O calendário do seu curso está atrasado";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="As datas do curso foram alteradas e seu calendário não está mais atualizado com a nova programação";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remover calendário do curso";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Sincronizando calendário";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade concluído";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Agradecemos sua compra. Você pode continuar de onde parou e aproveitar o acesso completo ao conteúdo do seu curso.";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -431,13 +432,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="Este curso não inclui nenhum vídeo";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} hora";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} horas";
 /* 1 minute */
 "COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} min";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "Este componente interativo ainda não está disponível para celulares\n\nExplore outras partes deste curso ou acesse na internet";
 /* Message shown when attempting to display content not available on the app, from dates tab */
@@ -529,7 +530,7 @@
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="Criar uma nova publicação";
 /* Chrome cast message */
-"CHROMECAST_MESSAGE"="Video is casting to remote device";
+"CHROMECAST_MESSAGE"="O vídeo está transmitindo para dispositivo remoto";
 /* Button text to initiate or confirm deletion */
 "DELETE"="Apagar";
 /* Discussion used in the segmented control Creating a new post */
@@ -611,9 +612,9 @@
 /* Endorsed text */
 "ENDORSED" = "Endossado";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="Esta seção do curso pode funcionar melhor em um navegador";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Abrir no browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -761,7 +762,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "Editar perfil";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="As informações do seu perfil só ficam visíveis para você. Somente seu nome de usuário pode ser visto por outros usuários no {platform_name}.";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "Editar perfil";
 /* Accessibility hint for country field in user profile */
@@ -881,17 +882,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "Esta configuração é para todos os vídeos baixados no aplicativo {platform_name}.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Qualidade do vídeo";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Automática (Recomendado)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Menor tamanho de arquivo)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Melhor qualidade)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="Entrar";
 /* Message shown while user waits for response to a sign in request */
@@ -967,37 +968,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "Perfil";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "Atualizar {course_name}";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "Atualizar agora por US${price}";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "Como desbloquear tarefas com nota";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "As tarefas com nota estão bloqueadas";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Atualizar e obter acesso a recursos exclusivos como este, para aproveitar o curso ao máximo.";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="Faça o upgrade para ter acesso a mais recursos";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Saiba mais";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Saiba mais sobre os recursos bloqueados";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="Receba um certificado verificado de conclusão para incluir no seu currículo";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="Desbloqueie o acesso a todas as atividades do curso, incluindo tarefas com nota";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="Acesso completo ao conteúdo e materiais do curso, mesmo após concluí-lo.";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="Exibir mais";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="Exibir menos";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/pt-BR.lproj/ProfileOptions.strings
+++ b/Source/pt-BR.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "Configurações de vídeo";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Baixar somente com Wi-Fi";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Baixar conteúdo somente quando conectado ao Wi-Fi";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "Informações pessoais";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "E-mail: {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Nome de usuário: {username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "No momento, você está compartilhando um perfil limitadoe";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "Compras";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restaurar compras";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Entre na App Store para restaurar o acesso aos cursos que você já pagou para atualizar";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "Ajuda";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Gostaria de solicitar alguma funcionalidade ou deixar uma opinião sobre nosso aplicativo?";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Enviar e-mail para a equipe de suporte";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Obter suporte";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "Para obter mais ajuda e saber como usar o aplicativo para dispositivos móveis {platform_name}, consulte nossa página de perguntas frequentes.";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "Visualizar perguntas frequentes";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sair";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Excluir conta";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Siga as instruções da próxima tela para excluir sua conta e todos os dados relacionados.";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Excluir sua conta";

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -265,23 +265,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Kaynaklar";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Plana uygun kalmanıza yardımcı olması için bitiş tarihleriniz başarıyla değiştirildi.";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "Tüm tarihleri görüntüle";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Önemli Tarihler";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="Tamamlandı";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="Tarihi Geçti";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="Sırada Tarihi Gelen";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="Henüz Yayınlanmadı";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="Yalnızca Onaylı";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="Bugün";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -301,73 +301,73 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Tarihleriniz başarıyla değiştirildi.";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Tarihleriniz değiştirilemedi. Lütfen tekrar deneyin.";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="Öğreniminizin planlandığı gibi gitmesine yardımcı olmak için önerilen bir program oluşturduk. ";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="Ancak endişelenmeyin, bu esnek bir program olduğu için kendi hızınızda öğrenebilirsiniz. Önerdiğimiz tarihlerin gerisinde kalırsanız bunları plana uygun kalmanızı sağlayacak şekilde ayarlayabileceksiniz.";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="Bu kursu denetlemektesiniz, ";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="dolayısıyla notlu ödevlere katılamazsınız. Bu kursun parçası olarak notlu ödevler tamamlamak için bugün yükseltme yapabilirsiniz.";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Şimdi yükselt";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="Bu kursu denetlemektesiniz, ";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="dolayısıyla notlu ödevlere katılamazsınız. Önerilen programımıza göre bazı önemli son tarihleri kaçırmışsınız gibi görünüyor. Bu kursun parçası olarak notlu ödevler tamamlamak ve tarihi geçmiş ödevleri geleceğe taşımak için bugün yükseltme yapabilirsiniz.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Önerilen programımıza göre bazı önemli son tarihleri kaçırmışsınız gibi görünüyor. ";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Plana uygun kalmak için bu programı güncelleyebilir ve tarihi geçmiş ödevleri geleceğe taşıyabilirsiniz. Endişelenmeyin, bitiş tarihlerinizi değiştirdiğinizde ilerlemenizin hiçbir kısmını kaybetmeyeceksiniz.";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Bitiş tarihlerini değiştir";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="Kurs Programı";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="Takvim ile senkronize et";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Bu kursa yönelik tüm son tarihleri ve bitiş tarihlerini otomatik olarak takviminizle senkronize edin.";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="\"{calendar_name}\" Takvimini Ekleyin";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="\"{calendar_name}\" takvimini kaldırın";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"="{platform_name} \"{calendar_name}\" takvimini eklemek ister misiniz? \n Kurs takviminizi Takvim veya Ayarlar kısmından herhangi bir zamanda düzenleyebilir veya kaldırabilirsiniz.";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="{platform_name} \"{calendar_name}\" takvimini kaldırmak istiyor musunuz?";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" telefonunuzun takvimine eklendi.";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="Kurs takviminiz eklendi.";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Kurs takviminiz kaldırıldı.";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Kurs takviminiz güncellendi.";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Kurs takviminiz güncel değil";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Kurs tarihleriniz değiştirildi ve kurs takviminiz artık yeni programınıza göre güncel değil.";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Ders Takvimini Kaldır";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Takvim senkronize ediliyor...";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Yükseltme tamamlandı";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Satın alım işleminiz için teşekkür ederiz. Tam kaldığınız yerden devam edebilir ve kurs içeriğinize tam erişimin tadını çıkarabilirsiniz.";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -431,13 +431,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="Bu ders herhangi bir video içermiyor";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} saat";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} saat";
 /* 1 minute */
-"COURSE_VIDEO_MINUTES##{one}" = "{minutes} minute";
+"COURSE_VIDEO_MINUTES##{one}" = "{minutes} dakika";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} minutes";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} dakika";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "Bu etkileşimli bileşen henüz mobilde mevcut değil. \n\n Bu diğer diğer kısımlarını keşfedin ya da web tarayıcısı üzerinden bakın.";
 /* Message shown when attempting to display content not available on the app, from dates tab */
@@ -529,7 +529,7 @@
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="Yeni bir gönderi oluştur";
 /* Chrome cast message */
-"CHROMECAST_MESSAGE"="Video is casting to remote device";
+"CHROMECAST_MESSAGE"="Video uzaktaki aygıta yayınlanıyor";
 /* Button text to initiate or confirm deletion */
 "DELETE"="Sil";
 /* Discussion used in the segmented control Creating a new post */
@@ -611,9 +611,9 @@
 /* Endorsed text */
 "ENDORSED" = "En İyi Cevap Olarak Seçildi";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="Kursun bu kısmı en iyi bir web tarayıcısında çalışabilir.";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Tarayıcıda açın";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -761,7 +761,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "Profili düzenle";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="Profil bilgileriniz yalnızca size görünür. {platform_name} üzerinde yalnızca kullanıcı adınız başkalarına görünür olur.";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "Profili düzenle";
 /* Accessibility hint for country field in user profile */
@@ -879,17 +879,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "Bu ayar {platform_name} uygulamasındaki tüm video indirme işlemleri içindir.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video indirme kalitesi";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Otomatik (Önerilen)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (En küçük dosya boyutu)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (En iyi kalite)";
 /* Text for a Twitter or Facebook post to a course about page */
 "SHARE_A_COURSE"="{platform_name} üzerinde ders alıyorum! Buna bir bak:";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
@@ -967,37 +967,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "Profil";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "{course_name} kursunu yükseltin";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "{price}$ karşılığında hemen yükseltin";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "Notlu ödevlerin kilidi nasıl açılır?";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Notlu ödevler kilitli";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Bunun gibi kilitli özelliklere erişim kazanmak ve kursunuzdan en iyi verimi almak için yükseltme yapın";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="Daha fazla özelliğe erişmek için yükseltme yapın";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Daha fazlası";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"=">Kilitli özellikler hakkında daha fazlasını öğrenin";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="Özgeçmişinizde sergileyebileceğiniz, doğrulanmış bir tamamlama sertifikası kazanın";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="Notlu ödevler dahil olmak üzere tüm kurs aktivitelerine erişimin kilidini açın";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="Kurs bittikten sonra dahi kurs içeriklerine ve kurs materyaline tam erişim";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="Daha fazlasını göster";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="Daha azını göster";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/tr.lproj/ProfileOptions.strings
+++ b/Source/tr.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "Video Ayarları";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Sadece Wi-Fi ile indir";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Sadece Wi-Fi açıkken içerik indir";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "Kişisel bilgiler";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "E-posta: {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Kullanıcı adı: {username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "Şu an kısıtlı profil paylaşıyorsunuze";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "Satın Alımlar";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "Satın alımları geri yükleyin";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Daha önce yükseltmek için ödeme yaptığınız kurslara erişimi geri yüklemek için Play Store\'da oturum açın";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "Yardım";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Bir özellik isteğinde bulunmak veya bize uygulamamıza dair geri bildirim vermek mi istiyorsunuz?";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Destek ekibine e-posta gönder";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Destek alın";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "Daha fazla yardım almak ve {platform_name} mobil uygulamasının nasıl kullanılacağını öğrenmek için sıkça sorulan sorular bölümümüzü ziyaret edin.";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "SSS'yi Görüntüle";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Oturumu kapat";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Hesabı sil";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Hesabınızı ve tüm ilgili verileri silmek için bir sonraki ekranda yer alan talimatları uygulayın.";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Hesabınızı silin";

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -261,23 +261,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="Nguồn";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Các ngày đến hạn đã được di chuyển thành công để giúp bạn luôn đi đúng hướng.";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "Xem tất cả mốc thời gian";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Những ngày quan trọng";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="Đã hoàn thành";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="Đã quá hạn";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="Sắp đến hạn";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="Chưa phát hành";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="Chỉ dành cho đã xác minh";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="Hôm nay";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -297,73 +297,71 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Các mốc thời gian của bạn đã được di chuyển thành công.";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Không thể di chuyển các mốc thời gian của bạn. Vui lòng thử lại.";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="Criamos uma programação como sugestão para ajudar você a se manter no caminho certo. ";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="Mas não se preocupe: ela é flexível, possibilitando que você aprenda no seu próprio ritmo. Se não conseguir se manter em dia com as datas sugeridas, você poderá ajustá-las da forma que for melhor para você.";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="Bạn đang dự thính khóa học này, ";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="điều này có nghĩa là bạn không thể tham gia vào các bài tập chấm điểm. Để hoàn thành các bài tập chấm điểm thuộc khóa học này, bạn có thể nâng cấp hôm nay.";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Nâng cấp ngay";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="Bạn đang dự thính khóa học này, ";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="điều này có nghĩa là bạn không thể tham gia vào các bài tập chấm điểm. Có vẻ như bạn đã bỏ lỡ một số hạn chót quan trọng dựa trên lịch biểu gợi ý của chúng tôi. Để hoàn thành các bài tập chấm điểm thuộc khóa học này và di chuyển các bài tập đã quá hạn đến tương lai, bạn có thể nâng cấp hôm nay.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Có vẻ như bạn đã bỏ lỡ một số hạn chót quan trọng dựa trên lịch biểu gợi ý của chúng tôi. ";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"=" Để duy trì đúng hướng đi, bạn có thể cập nhật lịch biểu này và di chuyển các bài tập đã quá hạn đến tương lai. Đừng lo lắng—bạn sẽ không mất bất kỳ tiến bộ nào mà bạn đã đạt được khi di chuyển ngày đến hạn.";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Di chuyển ngày đến hạn";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
-/* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="Lịch";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Tự động đồng bộ tất cả các hạn chót và ngày đến hạn cho khóa học này với lịch của bạn.";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="Thêm lịch \"{calendar_name}\"";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="Xóa lịch \"{calendar_name}\"";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"="Bạn có muốn thêm lịch {platform_name} \"{calendar_name}\" không? \n Bạn có thể chỉnh sửa hoặc xóa lịch khóa học của mình bất cứ lúc nào trong Lịch hoặc Cài đặt.";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"=">Bạn có muốn xóa lịch {platform_name} \"{calendar_name}\" không?";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" đã được thêm vào lịch trên điện thoại của bạn.";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="Lịch khóa học của bạn đã được thêm.";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Lịch khóa học của bạn đã được xóa.";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"=">Lịch khóa học của bạn đã được cập nhật.";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Lịch khóa học của bạn không cập nhật";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Các mốc thời gian của khóa học đã được di chuyển và lịch khóa học không còn cập nhật với lịch biểu mới của bạn nữa.";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Gỡ Lịch khóa học";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Đang đồng bộ lịch...";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Hoàn thành nâng cấp";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Cảm ơn bạn đã mua. Bạn có thể tiếp tục từ nơi bạn đã bở dở và tận hưởng quyền truy cập toàn bộ nội dung khóa học.";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -424,13 +422,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="Khóa học này không có video";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} giờ";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} giờ";
 /* 1 minute */
-"COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
+"COURSE_VIDEO_MINUTES##{one}" = "{minutes} phút";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} phút";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "Thành phần tương tác này chưa sẵn sàng trên di động.\n\nKhám phá những phần khác của khóa học hoặc xem phần này trên web.";
 /* Message shown when attempting to display content not available on the app, from dates tab */
@@ -519,7 +517,7 @@
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="Tạo bài đăng mới";
 /* Chrome cast message */
-"CHROMECAST_MESSAGE"="Video is casting to remote device";
+"CHROMECAST_MESSAGE"="Đang phát video đến một thiết bị từ xa";
 /* Button text to initiate or confirm deletion */
 "DELETE"="Xóa";
 /* Discussion used in the segmented control Creating a new post */
@@ -599,9 +597,9 @@
 /* Endorsed text */
 "ENDORSED" = "Chứng thực";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="Phần này của khóa học có thể hoạt động tốt nhất trên một trình duyệt web.";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Mở trong trình duyệt";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -749,7 +747,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "Chỉnh sửa hồ sơ";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="Thông tin hồ sơ của bạn chỉ hiển thị trước bạn. Chỉ có tên người dùng của bạn mới hiển thị trước những người khác trên {platform_name}.";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "Chỉnh sửa hồ sơ";
 /* Accessibility hint for country field in user profile */
@@ -866,17 +864,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "Cài đặt này áp dụng cho tất cả video tải xuống trong ứng dụng {platform_name}.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Chất lượng tải xuống video";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Tự động (Khuyên dùng)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Kích thước tệp nhỏ nhất)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Chất lượng cao nhất)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="Đăng nhập";
 /* Message shown while user waits for response to a sign in request */
@@ -952,37 +950,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "Hồ sơ";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "Nâng cấp {course_name}";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "Nâng cấp ngay với giá {price}$";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "Cách mở khóa bài tập chấm điểm";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Bài tập chấm điểm bị khóa";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Nâng cấp để có quyền truy cập các tính năng bị khóa như tính năng này và khai thác tối đa khóa học của bạn";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="Nâng cấp để truy cập thêm tính năng";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Tìm hiểu thêm";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Tìm hiểu thêm về các tính năng bị khóa";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="Giành chứng nhận hoàn thành được xác minh để thể hiện trên lý lịch của bạn";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="Mở khóa quyền truy cập tất cả các hoạt động khóa học, bao gồm bài tập chấm điểm";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="Quyền truy cập toàn bộ nội dung khóa học và tài liệu khóa học ngay cả sau khi kết thúc khóa học";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="Hiển thị thêm";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="Hiển thị ít hơn";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/vi.lproj/ProfileOptions.strings
+++ b/Source/vi.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "Cài đặt video";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Chỉ tải xuống bằng Wi-Fi";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Chỉ tải nội dung xuống khi Wi-Fi đang bật";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "Thông tin cá nhân";
 /* Settings user profile email */
 "PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Tên người dùng: {username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "Bạn đang chia sẻ hồ sơ cá nhân giới hạe";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "Mua";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "Khôi phục mua";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Đăng nhập vào App Store để khôi phục quyền truy cập các khóa học mà trước đó bạn đã trả tiền để nâng cấp";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "Trợ giúp";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Bạn muốn yêu cầu một tính năng hoặc đưa ra một số phản hồi về ứng dụng của chúng tôi?";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Gửi email cho nhóm hỗ trợ";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Nhận hỗ trợ";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "Để được trợ giúp thêm và tìm hiểu cách sử dụng ứng dụng di động {platform_name}, hãy truy cập phần hỏi đáp của chúng tôi.";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "Xem Hỏi đáp";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Đăng xuất";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Xóa tài khoản";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Làm theo hướng dẫn trên màn hình tiếp theo để xóa tài khoản của bạn và tất cả dữ liệu liên quan.";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Xóa tài khoản của bạn";

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -261,23 +261,23 @@
 /* Title of resources tab in course dashboardTabBar view */
 "RESOURSES"="资源";
 /* Course Dates Success Toast Message */
-"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "Your due dates have been successfully shifted to help you stay on track.";
+"COURSEDATES.TOAST_SUCCESS_MESSAGE" = "您已成功更改截止日期，因此可以保持学习进度。";
 /* Course Dates navigate to Dates screen*/
-"COURSEDATES.VIEW_ALL_DATES" = "View all dates";
+"COURSEDATES.VIEW_ALL_DATES" = "查看所有日期";
 /* Title of course important dates screen */
 "COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="重要日期";
 /* Course Date Type Completed */
-"COURSEDATES.COMPLETED"="Completed";
+"COURSEDATES.COMPLETED"="完成的";
 /* Course Date Type Past Due */
-"COURSEDATES.PAST_DUE"="Past Due";
+"COURSEDATES.PAST_DUE"="逾期的";
 /* Course Date Type Due Next */
-"COURSEDATES.DUE_NEXT"="Due Next";
+"COURSEDATES.DUE_NEXT"="即将到期";
 /* Course Date Type Unreleased */
-"COURSEDATES.UNRELEASED"="Not Yet Released";
+"COURSEDATES.UNRELEASED"="尚未发布";
 /* Course Date Completed */
-"COURSEDATES.VERFIED_ONLY"="Verified Only";
+"COURSEDATES.VERFIED_ONLY"="仅验证";
 /* Course Date Today*/
-"COURSEDATES.TODAY"="Today";
+"COURSEDATES.TODAY"="今天";
 /* Course date Assignment Due Date*/
 "COURSEDATES.ASSIGNMENT_DUE_DATE"="Assignment Due Date";
 /* Course Date Verified Upgrade Deadline*/
@@ -297,73 +297,73 @@
 /* Course Reset Date Title */
 "COURSEDATES.RESET_DATE.TITLE"="Course Dates";
 /* Course Reset Date Success Message */
-"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="Your dates have been successfully shifted.";
+"COURSEDATES.RESET_DATE.SUCCESS_MESSAGE"="您的日期已成功更改。";
 /* Course Reset Date Error Message */
-"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="Your dates could not be shifted. Please try again.";
+"COURSEDATES.RESET_DATE.ERROR_MESSAGE"="您的日期无法更改。请再次尝试。";
 /* Course Reset Date Tab Info Banner Header */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="We've built a suggested schedule to help you stay on track. ";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.HEADER"="我们制定了一个建议的时间表，以帮助您保持合理进度。";
 /* Course Reset Date Tab Info Banner Body */
-"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="But don't worry—it's flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates, you'll be able to adjust them to keep yourself on track.";
+"COURSEDATES.RESET_DATE.TAB_INFO_BANNER.BODY"="它很灵活，所以您可以按照自己的节奏学习。 如果您碰巧落后于我们建议的日期，您可以调整日期，让自己的学习保持进度。";
 /* Course Reset Date Upgrade To Complete Graded Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.HEADER"="您正在以审阅模式访问本课程，";
 /* Course Reset Date Upgrade To Complete Graded Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BODY"="这意味着你不能参加分级作业。要完成本课程一部分的分级作业，您可以今天进行功能升级。";
 /* Course Reset Date Upgrade To Complete Graded Banner Button */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="Upgrade now";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_COMPLETE_GRADED_BANNER.BUTTON"="立即升级";
 /* Course Reset Date Upgrade Reset Banner Header */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="You are auditing this course, ";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.HEADER"="您正在以审阅模式访问本课程，";
 /* Course Reset Date Upgrade Reset Banner Body */
-"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.";
+"COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="这意味着你不能参加分级作业。根据我们建议的日程安排，您似乎错过了一些重要的截止日期。要完成本课程一部分的分级作业，并将过去到期的作业转移到未来，您可以今天进行功能升级。";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="根据我们建议的日程安排，您似乎错过了一些重要的截止日期。";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="为了让自己赶上进程，您可以更新此计划并将过期的任务转移到未来。不要担心，当你改变你的截止日期时，你不会失去你已经取得的任何过程记录。";
 /* Course Reset Date Banner Button */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="改变截止日期";
 /* Course Dates Title */
-"COURSEDATES.COURSE_SCHEDULE"="Course Schedule";
+"COURSEDATES.COURSE_SCHEDULE"="课程表";
 /* Course Dates Sync To Calendar */
-"COURSEDATES.SYNC_TO_CALENDAR"="Sync to calendar";
+"COURSEDATES.SYNC_TO_CALENDAR"="同步到日程表";
 /* Course Dates Sync To Calendar Message */
-"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="Automatically sync all deadlines and due dates for this course to your calendar.";
+"COURSEDATES.SYNC_TO_CALENDAR_MESSAGE"="自动同步本课程所有最后期限和截止日期到你的日程表。";
 /* Course Dates Add Calendar Dialog Title */
-"COURSEDATES.ADD_CALENDAR_TITLE"="Add calendar \"{calendar_name}\"";
+"COURSEDATES.ADD_CALENDAR_TITLE"="在添加 \"{calendar_name}\"课程的日程安排内容";
 /* Course Dates Remove Calendar Dialog Title */
-"COURSEDATES.REMOVE_CALENDAR_TITLE"="Remove calendar \"{calendar_name}\"";
+"COURSEDATES.REMOVE_CALENDAR_TITLE"="删除\"{calendar_name}\" 课程相关的日程安排";
 /* Course Dates Add Calendar Message prompt */
-"COURSEDATES.ADD_CALENDAR_PROMPT"="Would you like to add the {platform_name} calendar \"{calendar_name}\" ? \n You can edit or remove the course calendar any time in Calendar or Settings";
+"COURSEDATES.ADD_CALENDAR_PROMPT"="需要在{platform_name} 日程中添加\"{calendar_name}\" 课程相关内容吗? \n 你可以在任意时间通过日程或设置编辑或者删除你课程的日程安排。";
 /* Course Dates Remove Calendar Message prompt */
-"COURSEDATES.REMOVE_CALENDAR_PROMPT"="Would you like to remove the {platform_name} calendar \"{calendar_name}\" ?";
+"COURSEDATES.REMOVE_CALENDAR_PROMPT"="你想从 {platform_name} 日程安排中删除 \"{calendar_name}\" 课程相关内容吗 ?";
 /* Course Dates Calendar has been added to your calendar*/
-"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" has been added to your calendar.";
+"COURSEDATES.DATES_ADDED_ALERT_MESSAGE" = "\"{calendar_name}\" 已添加到您手机上的日历。";
 /* Course Dates Open Settings */
 "COURSEDATES.OPEN_SETTINGS"="Open Settings";
 /* Course Dates Events Added to Calendar Success */
-"COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
+"COURSEDATES.CALENDAR_EVENTS_ADDED"="你的课程日程已经被添加";
 /* Course Dates Events Removed from Calendar */
-"COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
+"COURSEDATES.CALENDAR_EVENTS_REMOVED"="你课程的日程已经被删除。";
 /* Course Dates Events Updated in Calendar */
-"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="你的课程日程安排已经被更新。";
 /* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
 /* Course Dates Calendar Out of Date*/
-"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="您的课程日程已过期";
 /* Course Dates Calendar Shift Message */
-"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="您的课程日期已更改，当前您的课程日程表不再与您的新时间表保持同步";
 /* Course Dates Calendar Shift Prompt Update Now */
 "COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
 /* Course Dates Calendar Shift Prompt Remove Course Calendar */
-"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="删除课程日历";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Course Dates Calendar sync Message */
-"COURSEDATES.CALENDAR_SYNC_MESSAGE"="Syncing calendar...";
+"COURSEDATES.CALENDAR_SYNC_MESSAGE"="同步日历...";
 /*Course upgrade success alert title*/
-"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="Upgrade complete";
+"COURSE_UPGRADE.SUCCESS_ALERT_TITLE"="升级已完成";
 /*Course upgrade success alert message*/
-"COURSE_UPGRADE.SUCCESS_ALERT_Message"="Thank you for your purchase. You can pick up right where you left off and enjoy full access to your course content.";
+"COURSE_UPGRADE.SUCCESS_ALERT_Message"="感谢您的购买。您可以继续此前的学习，完全访问课程内容。";
 /*Course upgrade success alert continue button title*/
 "COURSE_UPGRADE.SUCCESS_ALERT_CONTINUE"="Continue";
 /*Course upgrade failure alert title*/
@@ -424,13 +424,13 @@
 /* Message shown when there is no course video */
 "COURSE_VIDEO_UNAVAILABLE"="此课程没有任何视频。";
 /* 1 hour */
-"COURSE_VIDEO_HOURS##{one}" = "{hours} hour";
+"COURSE_VIDEO_HOURS##{one}" = "{hours} 小时";
 /* More than 1 hours */
-"COURSE_VIDEO_HOURS##{other}" = "{hours} hours";
+"COURSE_VIDEO_HOURS##{other}" = "{hours} 小时";
 /* 1 minute */
-"COURSE_VIDEO_MINUTES##{one}" = "{minutes} min";
+"COURSE_VIDEO_MINUTES##{one}" = "{minutes} 分钟";
 /* More than 1 minute */
-"COURSE_VIDEO_MINUTES##{other}" = "{minutes} mins";
+"COURSE_VIDEO_MINUTES##{other}" = "{minutes} 分钟";
 /* Message shown when attempting to display content not available on the app */
 "COURSE_CONTENT_UNKNOWN" = "此组件在手机上不可用。\n\n请浏览此课程的其他部分或在网页中观看。";
 /* Message shown when there is no course dates */
@@ -519,7 +519,7 @@
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="创建新帖子";
 /* Chrome cast message */
-"CHROMECAST_MESSAGE"="Video is casting to remote device";
+"CHROMECAST_MESSAGE"="视频将投射到远程设备上";
 /* Button text to initiate or confirm deletion */
 "DELETE"="删除";
 /* Discussion used in the segmented control Creating a new post */
@@ -599,9 +599,9 @@
 /* Endorsed text */
 "ENDORSED" = "已认可";
 /*Open in external browser banner message*/
-"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="课程这部分的内容最好在web浏览器中访问。";
 /*Open in external browser banner underline text*/
-"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="在浏览器打开";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
@@ -749,7 +749,7 @@
 /* Profile edit view title */
 "PROFILE.EDIT_TITLE" = "编辑资料";
 /* Profile screen fields visibility off info message */
-"PROFILE.VISIBILITY_OFF_MESSGAE"="Your profile information is only visible to you. Only your username is visible to others on {platform_name}.";
+"PROFILE.VISIBILITY_OFF_MESSGAE"="你的属性信息只能由你浏览。对于{paltform_name}上的其他用户只显示你的用户名。";
 /* Accessibility label for edit profile button */
 "PROFILE.EDIT_ACCESSIBILITY" = "编辑资料";
 /* Accessibility hint for country field in user profile */
@@ -866,17 +866,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "这个设置是关于如何在{platform_name} app中下载视频的。";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "视频下载质量";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "自动 (建议的)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (最小的文件尺寸)";
 /* Settigs message for Video Download Quality Low */
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (最好质量)";
 /* Sign in screen title and button initiating login process after user enters credentials like username and password */
 "SIGN_IN_TEXT"="登录";
 /* Message shown while user waits for response to a sign in request */
@@ -952,37 +952,33 @@
 /* Button title for profile view in account*/
 "USER_ACCOUNT.PROFILE"= "个人资料";
 /* Value prop upgrade text */
-"VALUE_PROP.UPGRADE"= "Upgrade {course_name}";
+"VALUE_PROP.UPGRADE"= "升级{course_name}的访问模式";
 /* Value prop upgrade button text with price */
-"VALUE_PROP.UPGRADE_COURSE_FOR"= "Upgrade now for ${price}";
+"VALUE_PROP.UPGRADE_COURSE_FOR"= "现在升级仅需 ${price}";
 /* Message shown when course content is gated, prompt user how to unlock */
-"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "How to unlock graded assignments";
+"VALUE_PROP.LEARN_HOW_TO_UNLOCK"= "如何解锁分级作业";
 /* Message shown when course content is gated, on button */
 "VALUE_PROP.LEARN_MORE"= "Learn more";
 /* Message shown when course content is gated, new message behind feature flag */
-"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "Graded assignments are locked";
+"VALUE_PROP.ASSIGNMENTS_ARE_LOCKED"= "分级作业已锁定";
 /* Message shown when course content is gated, upgrade to access, new message behind feature flag */
-"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "Upgrade to gain access to locked features like this one and get the most out of your course";
+"VALUE_PROP.UPGRADE_TO_ACCESS_GRADED" = "升级以获得对锁定功能的访问，如此功能或更多关于本课程的访问能力";
 /* Value prop view's message on enrolled courses*/
-"VALUE_PROP.COURSE_CARD_MESSAGE"="Upgrade to access more features";
+"VALUE_PROP.COURSE_CARD_MESSAGE"="升级以访问更多功能";
 /* Value prop view's learn more button title on enrolled courses*/
-"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="Learn more";
+"VALUE_PROP.LEARN_MORE_BUTTON_TITLE"="了解更多详情";
 /* Value prop detail view title learn more*/
-"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="Learn more about locked features";
-/* Value prop detail view title*/
-"VALUE_PROP.DETAIL_VIEW_TITLE"="Access to edX course features";
-/* Value prop detail view message heading*/
-"VALUE_PROP.DETAIL_VIEW_MESSAGE_TITLE"="When you upgrade, you:";
+"VALUE_PROP.DETAIL_VIEW_TITLE_LEARN_MORE"="了解关于锁定功能的更多详情";
 /* Value prop information message number one*/
-"VALUE_PROP.INFO_MESSAGE_1"="Earn a verified certificate of completion to showcase on your resumé";
+"VALUE_PROP.INFO_MESSAGE_1"="获得一份经过验证的结业证书，以便在简历上展示";
 /* Value prop information message number two*/
-"VALUE_PROP.INFO_MESSAGE_2"="Unlock access to all course activities, including graded assignments";
+"VALUE_PROP.INFO_MESSAGE_2"="解锁所有课程活动的访问权限，包括分级作业";
 /* Value prop information message number three*/
-"VALUE_PROP.INFO_MESSAGE_3"="Full access to course content and material, even after the course ends";
+"VALUE_PROP.INFO_MESSAGE_3"="即使在课程结束后，也可以完全访问课程内容和课程材料";
 /* Show more button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_MORE_TEXT"="Show more";
+"VALUE_PROP.SHOW_MORE_TEXT"="显示更多";
 /* Show less button text on the component screen on the value prop banner*/
-"VALUE_PROP.SHOW_LESS_TEXT"="Show less";
+"VALUE_PROP.SHOW_LESS_TEXT"="简略显示";
 /* Value prop button text on course dashbaord screen*/
 "VALUE_PROP.COURSE_DASHBOARD_BUTTON_TITLE"="Upgrade to access more features";
 /* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */

--- a/Source/zh-Hans.lproj/ProfileOptions.strings
+++ b/Source/zh-Hans.lproj/ProfileOptions.strings
@@ -1,50 +1,42 @@
 /* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "视频设置";
 /* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "仅在Wi-Fi下载";
 /* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "仅在Wi-Fi开启时下载内容";
 /* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
-/* Settings title for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
-/* Settings heading for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
-/* Settings message for video settings */
-"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
-/* Settings title for profile information */
-"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
+"PROFILE_OPTIONS.USER_PROFILE.TITLE" = "个人信息";
 /* Settings user profile email */
-"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "Email: {email}";
+"PROFILE_OPTIONS.USER_PROFILE.EMAIL" = "电子邮件: {email}";
 /* Settings user profile username */
-"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "Username: {username}";
+"PROFILE_OPTIONS.USER_PROFILE.USERNAME" = "用户名：{username}";
 /* Settings message for profile */
-"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "You are currently sharing a limited profile";
+"PROFILE_OPTIONS.USER_PROFILE.MESSAGE" = "您当前仅分享部分资料";
 /* Settings title for purchases */
-"PROFILE_OPTIONS.PURCHASES.TITLE" = "PURCHASES";
+"PROFILE_OPTIONS.PURCHASES.TITLE" = "购买";
 /* Settings heading for purchases */
-"PROFILE_OPTIONS.PURCHASES.HEADING" = "Restore purchases";
+"PROFILE_OPTIONS.PURCHASES.HEADING" = "恢复购买";
 /* Settings message for purchases */
-"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "Sign into the app store to restore access to courses you have previously paid to upgrade";
+"PROFILE_OPTIONS.PURCHASES.MESSAGE" = "登录App Store以恢复您以前已付费的课程的访问权限";
 /* Settings title for HELP */
-"PROFILE_OPTIONS.HELP.TITLE" = "HELP";
+"PROFILE_OPTIONS.HELP.TITLE" = "帮助";
 /* Settings heading for feedback */
 "PROFILE_OPTIONS.HELP.HEADING.FEEDBACK" = "Submit feedback";
 /* Settings message for feedback */
-"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "Looking to make a feature request or give us some feedback on our app?";
+"PROFILE_OPTIONS.HELP.MESSAGE.FEEDBACK" = "希望对我们的应用程序提出功能请求或提供一些反馈？";
 /* Settings message for feedback button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "Email the support team";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.FEEDBACK" = "发email给支持服务团队";
 /* Settings heading for support */
-"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "Get support";
+"PROFILE_OPTIONS.HELP.HEADING.SUPPORT" = "获取支持";
 /* Settings message for support */
-"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "To get more help and learn how to use the {platform_name} mobile app, visit our frequently asked questions.";
+"PROFILE_OPTIONS.HELP.MESSAGE.SUPPORT" = "要获得更多帮助并了解如何使用{platform_name}移动应用程序，请访问我们的常见问题解答。";
 /* Settings message for view faq button title */
-"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "View FAQ";
+"PROFILE_OPTIONS.HELP.BUTTON_TITLE.VIEW_FAQ" = "访问FAQ";
 /* Settings message for signout button title */
-"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "Sign out";
+"PROFILE_OPTIONS.SIGNOUT.BUTTON_TITLE" = "登出";
 /* Settings title for delete account button */
-"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "Delete account";
+"PROFILE_OPTIONS.DELETEACCOUNT.BUTTON_TITLE" = "删除账户";
 /* Settings info message for delete account */
-"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "Follow the instructions on the next screen to delete your account and all related data.";
+"PROFILE_OPTIONS.DELETEACCOUNT.INFO_MESSAGE" = "按照下一屏幕上的说明删除您的帐户和所有相关数据。";
 /* Settings title for delete account web view*/
-"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "Delete your account";
+"PROFILE_OPTIONS.DELETEACCOUNT.WEBVIEW_TITLE" = "删除你的账户";


### PR DESCRIPTION
### Description

[LEARNER-8516](https://openedx.atlassian.net/browse/LEARNER-8516)

Pulled the latest translations that broke down on the android platform into multiple files according to the features and updated the strings of the iOS app.

### Files
I've pulled the following files from the transifex and updated the relevant sprints on the iOS side.

- [course_dates_strings](https://www.transifex.com/open-edx/edx-mobile-apps/android-app-course_dates_strings/) 
- [course_banners_strings](https://www.transifex.com/open-edx/edx-mobile-apps/android-app-course_banners_strings/)
- [course_modal_strings](https://www.transifex.com/open-edx/edx-mobile-apps/android-app-course_modal_strings/)
- [iap_strings](https://www.transifex.com/open-edx/edx-mobile-apps/android-app-iap_strings/)
- [video_strings](https://www.transifex.com/open-edx/edx-mobile-apps/android-app-video_strings/)
- [profile_strings](https://www.transifex.com/open-edx/edx-mobile-apps/android-app-profile_strings/)

