### PR TITLE
[fix] hide special exam block components

### DIFF
--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -77,7 +77,8 @@ public struct CourseOutline {
                 let isCompleted = body[Fields.isCompleted].boolValue
                 let specialExamInfo = body[Fields.SpecialExamInfo].dictionaryObject
                 
-                // TODO: quick fix for LEARNER-8708, to hide special exam components
+                // quick fix for LEARNER-8708, to hide special exam components
+                // TODO: may or may not change after final decision from product
                 if specialExamInfo != nil {
                     children = []
                 }

--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -60,7 +60,7 @@ public struct CourseOutline {
             for (blockID, blockBody) in blocks {
                 let body = JSON(blockBody)
                 let webURL = NSURL(string: body[Fields.LMSWebURL].stringValue)
-                let children = body[Fields.Descendants].arrayObject as? [String] ?? []
+                var children = body[Fields.Descendants].arrayObject as? [String] ?? []
                 let name = body[Fields.DisplayName].string
                 let dueDate = body[Fields.DueDate].string
                 let blockURL = body[Fields.StudentViewURL].string.flatMap { NSURL(string:$0) }
@@ -76,6 +76,11 @@ public struct CourseOutline {
                 let authorizationDenialMessage = body[Fields.AuthorizationDenialMessage].string
                 let isCompleted = body[Fields.isCompleted].boolValue
                 let specialExamInfo = body[Fields.SpecialExamInfo].dictionaryObject
+                
+                // fix for LEARNER-8708, to hide special exam components, need to revist this
+                if specialExamInfo != nil {
+                    children = []
+                }
                 
                 var type : CourseBlockType
                 if let category = CourseBlock.Category(rawValue: typeName) {

--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -77,7 +77,7 @@ public struct CourseOutline {
                 let isCompleted = body[Fields.isCompleted].boolValue
                 let specialExamInfo = body[Fields.SpecialExamInfo].dictionaryObject
                 
-                // fix for LEARNER-8708, to hide special exam components, need to revist this
+                // TODO: quick fix for LEARNER-8708, to hide special exam components
                 if specialExamInfo != nil {
                     children = []
                 }


### PR DESCRIPTION
### Description

[LEARNER-8708](https://openedx.atlassian.net/browse/LEARNER-8708)

This PR hides special exam block components from the course components screen