### PR TITLE
[fix] add calendar event deeplink if link is available to user

### DIFF
--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -231,7 +231,7 @@ class CalendarManager: NSObject {
         let endDate = block.blockDate
         var notes = "\(courseName)\n\n\(block.title)"
         
-        if generateDeepLink && branchEnabled {
+        if generateDeepLink && block.isAvailable && branchEnabled {
             if let link = generateDeeplink(componentBlockID: block.firstComponentBlockID) {
                 notes = notes + "\n\(link)"
             }
@@ -250,7 +250,7 @@ class CalendarManager: NSObject {
         let secondAlert = startDate.add(.day, value: alertOffset)
         let endDate = block.blockDate
         let notes = "\(courseName)\n\n" + blocks.compactMap { block -> String in
-            if generateDeepLink && branchEnabled {
+            if generateDeepLink && block.isAvailable && branchEnabled {
                 if let link = generateDeeplink(componentBlockID: block.firstComponentBlockID) {
                     return "\(block.title)\n\(link)"
                 } else {


### PR DESCRIPTION
### Description

[LEARNER-8739](https://openedx.atlassian.net/browse/LEARNER-8739)

App is crashing while tapping deeplink from Calendar as it was opening malfunction deeplink when user does not have access to course component

### How to test this PR
- [ ] Test on a verified course with user having audit enrolment mode (Course: Theories of Media and Technology)
- [ ] Sync course dates to calender
- [ ] For components a user does not have access, synced calendar events should not contain a deeplink url
