### PR TITLE
[chore] upgrade edx-app-gradle-plugin to latest commit hash

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -58,4 +58,4 @@ def edXAppPluginSetup(url, ref) {
     grgit.checkout(branch : ref)
 }
 
-edXAppPluginSetup('https://github.com/edx/edx-app-gradle-plugin', 'b38aedc320978d070c33637a3ae6d4a0060dafea')
+edXAppPluginSetup('https://github.com/openedx/edx-app-gradle-plugin', 'd2a99e60a229502c9997830898c94a4dbadf4385')

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -58,4 +58,4 @@ def edXAppPluginSetup(url, ref) {
     grgit.checkout(branch : ref)
 }
 
-edXAppPluginSetup('https://github.com/openedx/edx-app-gradle-plugin', 'd2a99e60a229502c9997830898c94a4dbadf4385')
+edXAppPluginSetup('https://github.com/openedx/edx-app-gradle-plugin', 'c77472e57075f1c3eb3480a3fbe19f4c00551713')


### PR DESCRIPTION
### Description

[LEARNER-8736](https://openedx.atlassian.net/browse/LEARNER-8736)

upgrade edx-app-gradle-plugin to latest commit hash [link](https://github.com/openedx/edx-app-gradle-plugin/commit/c77472e57075f1c3eb3480a3fbe19f4c00551713) which replaces `compile` to `implementation` 

[link](https://github.com/openedx/edx-app-gradle-plugin/blob/c77472e57075f1c3eb3480a3fbe19f4c00551713/build.gradle) to file