### PR TITLE
[feat] handle Get Support upon error during IAP

### DIFF
--- a/Source/CourseUpgradeCompletion.swift
+++ b/Source/CourseUpgradeCompletion.swift
@@ -7,10 +7,11 @@
 //
 
 import Foundation
+import MessageUI
 
 let CourseUpgradeCompletionNotification = "CourseUpgradeCompletionNotification"
 
-class CourseUpgradeCompletion {
+class CourseUpgradeCompletion: NSObject {
     
     static let courseID = "CourseID"
     static let blockID = "BlockID"
@@ -23,7 +24,7 @@ class CourseUpgradeCompletion {
         case error
     }
     
-    private init() { }
+    private override init() { }
     
     func handleCourseUpgrade(state: CompletionState, screen: CourseUpgradeScreen) {
         switch state {
@@ -50,11 +51,39 @@ class CourseUpgradeCompletion {
     func showError() {
         guard let topController = UIApplication.shared.topMostController() else { return }
         let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.failureAlertTitle, message: Strings.CourseUpgrade.failureAlertMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
-        alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { action in
-            
+        alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { [weak self] action in
+            self?.launchEmailComposer()
         }
         alertController.addButton(withTitle: Strings.close, style: .default) { action in
             
         }
+    }
+}
+
+extension CourseUpgradeCompletion: MFMailComposeViewControllerDelegate {
+    fileprivate func launchEmailComposer() {
+        guard let controller = UIApplication.shared.window?.rootViewController else { return }
+
+        if !MFMailComposeViewController.canSendMail() {
+            UIAlertController().showAlert(withTitle: Strings.emailAccountNotSetUpTitle, message: Strings.emailAccountNotSetUpMessage, onViewController: controller)
+        } else {
+            let mail = MFMailComposeViewController()
+            mail.mailComposeDelegate = self
+            mail.navigationBar.tintColor = OEXStyles.shared().navigationItemTintColor()
+            mail.setSubject(Strings.CourseUpgrade.getSupportEmailSubject)
+
+            mail.setMessageBody(EmailTemplates.supportEmailMessageTemplate(), isHTML: false)
+            if let fbAddress = OEXRouter.shared().environment.config.feedbackEmailAddress() {
+                mail.setToRecipients([fbAddress])
+            }
+            controller.present(mail, animated: true, completion: nil)
+
+        }
+    }
+
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        guard let controller = UIApplication.shared.window?.rootViewController else { return }
+
+        controller.dismiss(animated: true, completion: nil)
     }
 }

--- a/Source/CourseUpgradeCompletion.swift
+++ b/Source/CourseUpgradeCompletion.swift
@@ -77,7 +77,6 @@ extension CourseUpgradeCompletion: MFMailComposeViewControllerDelegate {
                 mail.setToRecipients([fbAddress])
             }
             controller.present(mail, animated: true, completion: nil)
-
         }
     }
 

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -392,6 +392,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="إلغاء";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="Abbrechen";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="Cancel";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="Annuler";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -384,6 +384,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="ביטול";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -374,6 +374,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="キャンセル";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -377,6 +377,8 @@ Se você não conseguir acompanhar tudo nas datas sugeridas, você poderá ajust
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="Cancelar";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="İptal";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -370,6 +370,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="Hủy";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -372,6 +372,8 @@
 "COURSE_UPGRADE.FAILURE_ALERT_Message"="It looks like something went wrong when upgrading your course.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
+/*Get support e-mail subject in the payment error flow*/
+"COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */
 "CANCEL"="取消";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */


### PR DESCRIPTION
### Description

[LEARNER-8728](https://openedx.atlassian.net/browse/LEARNER-8728)

Send an email to the support team when the user clicks on the Get Support button on the error dialogue.  

### How to test this PR

- [x]  Open email composer on clicking the `Get Help` button on the IAP error alert.

