### PR TITLE
[feat] Show Value Prop Button on Course Dashboard

### DIFF
--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -131,9 +131,9 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
         let button = UIButton(type: .system)
         button.oex_addAction({ [weak self] _ in
             if let course = self?.enrollment?.course {
-                self?.environment.router?.showValuePropDetailView(from: self, screen: .courseDashboard, course: course, completion:{
+                self?.environment.router?.showValuePropDetailView(from: self, screen: .courseDashboard, course: course) {
                     self?.environment.analytics.trackValuePropModal(with: .CourseDashboard, courseId: course.course_id ?? "")
-                })
+                }
                 self?.environment.analytics.trackValuePropLearnMore(courseID: course.course_id ?? "", screenName: .CourseDashboard)
             }
         }, for: .touchUpInside)

--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -97,11 +97,7 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
     }
 
     private var canShowValueProp: Bool {
-        guard let enrollment = enrollment, enrollment.type == .audit && environment.remoteConfig.valuePropEnabled
-        else { return false }
-
-        // TODO: It's a temporary fix, will be reverted under LEARNER-8738
-        return environment.config.inappPurchasesEnabled
+        return enrollment?.type == .audit && environment.remoteConfig.valuePropEnabled
     }
 
     private var enrollment: UserCourseEnrollment? {
@@ -135,7 +131,10 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
         let button = UIButton(type: .system)
         button.oex_addAction({ [weak self] _ in
             if let course = self?.enrollment?.course {
-                self?.environment.router?.showValuePropDetailView(from: self, screen: .courseDashboard, course: course, completion: nil)
+                self?.environment.router?.showValuePropDetailView(from: self, screen: .courseDashboard, course: course, completion:{
+                    self?.environment.analytics.trackValuePropModal(with: .CourseDashboard, courseId: course.course_id ?? "")
+                })
+                self?.environment.analytics.trackValuePropLearnMore(courseID: course.course_id ?? "", screenName: .CourseDashboard)
             }
         }, for: .touchUpInside)
 


### PR DESCRIPTION
### Description

[LEARNER-8738](https://openedx.atlassian.net/browse/LEARNER-8738)

The value prop button was hidden for release 3.1.0 under the ticket [LEARNER-8737:  iOS - Hide Value Prop Button from DashboardMERGED](https://openedx.atlassian.net/browse/LEARNER-8737) because analytics were not implemented and was made dependent on an additional flag IAP_Enabled as a temporary fix.

This PR removes the dependency of the value prop button on the course dashboard from IAP-Enabled and implement the analytics for the value prop button.
