### PR TITLE
[feat] Send IAP Error Details in Support Email

### DIFF
--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -103,8 +103,8 @@ extension CourseUpgradeHelper: MFMailComposeViewControllerDelegate {
             mail.mailComposeDelegate = self
             mail.navigationBar.tintColor = OEXStyles.shared().navigationItemTintColor()
             mail.setSubject(Strings.CourseUpgrade.getSupportEmailSubject)
-
-            mail.setMessageBody(EmailTemplates.supportEmailMessageTemplate(), isHTML: false)
+            let body = EmailTemplates.supportEmailMessageTemplate(error: "Error: \(CourseUpgradeHandler.shared.formattedUpgradeError)")
+            mail.setMessageBody(body, isHTML: false)
             if let fbAddress = OEXRouter.shared().environment.config.feedbackEmailAddress() {
                 mail.setToRecipients([fbAddress])
             }

--- a/Source/EmailTemplates.swift
+++ b/Source/EmailTemplates.swift
@@ -10,12 +10,15 @@ import UIKit
 
 @objc class EmailTemplates: NSObject {
     
-  @objc static func supportEmailMessageTemplate() -> String {
+    @objc static func supportEmailMessageTemplate(error: String? = nil) -> String {
         let osVersionText = Strings.SubmitFeedback.osVersion(version: UIDevice.current.systemVersion)
         let appVersionText = Strings.SubmitFeedback.appVersion(version: Bundle.main.oex_shortVersionString(), build: Bundle.main.oex_buildVersionString())
         let deviceModelText = Strings.SubmitFeedback.deviceModel(model: UIDevice.current.model)
-        let body = ["\n", Strings.SubmitFeedback.marker, osVersionText, appVersionText, deviceModelText].joined(separator: "\n")
-        return body
+        var body = ["\n", Strings.SubmitFeedback.marker, osVersionText, appVersionText, deviceModelText]
+        if let error = error {
+            body.append(error)
+        }
+        return body.joined(separator: "\n")
     }
     
 }

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -707,7 +707,7 @@
     mailComposer.mailComposeDelegate = self;
     mailComposer.navigationBar.tintColor = [[OEXStyles sharedStyles] navigationItemTintColor];
     [mailComposer setSubject:[Strings accountDisabled]];
-    [mailComposer setMessageBody:[EmailTemplates supportEmailMessageTemplate] isHTML:false];
+    [mailComposer setMessageBody:[EmailTemplates supportEmailMessageTemplateWithError:nil] isHTML:false];
 
     NSString *fbAddress = self.environment.config.feedbackEmailAddress;
     if (fbAddress) {

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -671,7 +671,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     mailComposer.mailComposeDelegate = self;
     mailComposer.navigationBar.tintColor = [[OEXStyles sharedStyles] navigationItemTintColor];
     [mailComposer setSubject:[Strings accountDisabled]];
-    [mailComposer setMessageBody:[EmailTemplates supportEmailMessageTemplate] isHTML:false];
+    [mailComposer setMessageBody:[EmailTemplates supportEmailMessageTemplateWithError:nil] isHTML:false];
 
     NSString *fbAddress = self.environment.config.feedbackEmailAddress;
     if (fbAddress) {

--- a/Source/PaymentManager.swift
+++ b/Source/PaymentManager.swift
@@ -35,7 +35,7 @@ enum PurchaseError: String {
     // Use this dictionary to keep track of inprocess transctions and allow only one transction at a time
     private var purchasess: [String: Any] = [:]
 
-    typealias PurchaseCompletionHandler = ((success: Bool, receipt: String?, error: PurchaseError?)) -> Void
+    typealias PurchaseCompletionHandler = ((success: Bool, receipt: String?, error: (type: PurchaseError?, error: Error?)?)) -> Void
     var completion: PurchaseCompletionHandler?
 
     var isIAPInprocess:Bool {
@@ -78,12 +78,12 @@ enum PurchaseError: String {
             if let controller = UIApplication.shared.topMostController() {
                 UIAlertController().showAlert(withTitle: "Payment Error", message: "This device is not able or allowed to make payments", onViewController: controller)
             }
-            completion?((false, receipt: nil, error: .paymentsNotAvailebe))
+            completion?((false, receipt: nil, error:(type: .paymentsNotAvailebe, error: nil)))
             return
         }
 
         guard let applicationUserName = OEXSession.shared()?.currentUser?.username else {
-            completion?((false, receipt: nil, error: .invalidUser))
+            completion?((false, receipt: nil, error: (type: .invalidUser, error: NSError(domain: "edx.app.payment", code: -1010, userInfo: [NSLocalizedDescriptionKey : "App username is not available"]))))
             return
         }
         self.completion = completion
@@ -95,7 +95,7 @@ enum PurchaseError: String {
                 self?.purchaseReceipt()
                 break
             case .error(let error):
-                completion?((false, receipt: nil, error: .paymentError))
+                completion?((false, receipt: nil, error: (type: .paymentError, error: error)))
                 switch error.code {
                 //TOD: handle the following cases according to the requirments
                 case .unknown:
@@ -144,8 +144,8 @@ enum PurchaseError: String {
             case .success(let receiptData):
                 let encryptedReceipt = receiptData.base64EncodedString(options: [])
                 self?.completion?((true, receipt: encryptedReceipt, error: nil))
-            case .error(_):
-                self?.completion?((false, receipt: nil, error: .receiptNotAvailable))
+            case .error(let error):
+                self?.completion?((false, receipt: nil, error: (type: .receiptNotAvailable, error: error)))
             }
         }
     }


### PR DESCRIPTION
### Description

[LEARNER-8762](https://openedx.atlassian.net/browse/LEARNER-8762)

Pre-req: Mappings to be finalized in this ticket: [LEARNER-8758](https://openedx.atlassian.net/browse/LEARNER-8758)

According to the Figma file, it’s intended to send only the error code in the support email, but we are getting the same error codes in different cases like `400: {'error': 'Basket [basket id] not found'`} and `400: {'error': 'Payment processor [payment processor] not found'}` getting 400 in two different cases. So the team decides to send more information in the error field of the email. `The team decides to send the details like Error: error_location(basket/checkout/payment/etc)-error_code-error_message` 

**Examples:**
Error: basket-401-Failed to retrieve user info. Unable to authenticate.
Error: payment-2-The operation couldn’t be completed. (SKErrorDomain error 2.)

### Notes

### How to test this PR
