### PR TITLE
[feat] Give A Retry Option to Learner in Failed IAP After The Payment

### DIFF
--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -208,7 +208,9 @@ public class CourseOutlineViewController :
             }
         } failure: { [weak self] error in
             if let _ = self?.courseUpgradeHelper.courseUpgradeModel {
-                self?.courseUpgradeHelper.removeLoader(success: false, controller: self, selector: #selector(self?.loadCourseOutlineStream))
+                self?.courseUpgradeHelper.removeLoader(success: false) {
+                    self?.loadCourseOutlineStream()
+                }
             }
             Logger.logError("ANALYTICS", "Unable to load block: \(error)")
         }

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -186,7 +186,7 @@ public class CourseOutlineViewController :
     
     private var courseOutlineLoaded = false
     
-    private func loadCourseOutlineStream() {
+    @objc private func loadCourseOutlineStream() {
         if let _ = courseUpgradeHelper.courseUpgradeModel {
             courseQuerier.needsRefresh = true
         }
@@ -208,7 +208,7 @@ public class CourseOutlineViewController :
             }
         } failure: { [weak self] error in
             if let _ = self?.courseUpgradeHelper.courseUpgradeModel {
-                self?.courseUpgradeHelper.removeLoader()
+                self?.courseUpgradeHelper.removeLoader(success: false, controller: self, selector: #selector(self?.loadCourseOutlineStream))
             }
             Logger.logError("ANALYTICS", "Unable to load block: \(error)")
         }
@@ -332,7 +332,8 @@ public class CourseOutlineViewController :
     
     private func handleNavigationIfNeeded() {
         if let courseUpgradeModel = courseUpgradeHelper.courseUpgradeModel {
-            courseUpgradeHelper.courseUpgradeModel = nil
+            courseUpgradeHelper.resetUpgradeModel()
+
             if courseUpgradeModel.screen == .courseDashboard {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
                     self?.courseUpgradeHelper.removeLoader(success: true)

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -221,10 +221,10 @@ extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
                 upgradeView.updateUpgradeButtonVisibility(visible: false)
                 self?.courseUpgradeHelper.handleCourseUpgrade(state: .success(self?.courseID ?? "", self?.blockID), screen: .courseUnit)
                 break
-            case .error:
+            case .error(let type, _):
                 self?.enableUserInteraction(enable: true)
                 upgradeView.stopAnimating()
-                self?.courseUpgradeHelper.handleCourseUpgrade(state: .error, screen: .courseUnit)
+                self?.courseUpgradeHelper.handleCourseUpgrade(state: .error(type), screen: .courseUnit)
                 break
             default:
                 break

--- a/Source/CourseUpgradeAPI.swift
+++ b/Source/CourseUpgradeAPI.swift
@@ -29,14 +29,14 @@ public struct CourseUpgradeAPI {
             deserializer: .jsonResponse(basketDeserializer))
     }
     
-    private static func checkoutDeserializer(response : HTTPURLResponse) -> Result<()> {
+    private static func checkoutDeserializer(response: HTTPURLResponse, json: JSON) -> Result<CheckoutBasket> {
         guard response.httpStatusCode.is2xx else {
-            return Failure(e: NSError(domain: "CheckoutApiErrorDomain", code: response.statusCode, userInfo: [NSLocalizedDescriptionKey: "Checkout api error"]))
+            return Failure(e: NSError(domain: "CheckoutApiErrorDomain", code: response.statusCode, userInfo: [NSLocalizedDescriptionKey: json]))
         }
-        return Success(v: ())
+        return Success(v: CheckoutBasket(json: json))
     }
 
-    static func checkoutAPI(basketID: Int) -> NetworkRequest<()> {
+    static func checkoutAPI(basketID: Int) -> NetworkRequest<CheckoutBasket> {
         return NetworkRequest(
             method: .POST,
             path: "/api/v2/checkout/",
@@ -45,7 +45,7 @@ public struct CourseUpgradeAPI {
                 "basket_id": basketID,
                 "payment_processor": PaymentProcessor
             ])),
-            deserializer: .noContent(checkoutDeserializer)
+            deserializer: .jsonResponse(checkoutDeserializer)
         )
     }
     
@@ -72,7 +72,7 @@ public struct CourseUpgradeAPI {
     }
 }
 
-class OrderBasket: NSObject {
+struct OrderBasket {
     let success: String
     let basketID: Int
     
@@ -82,7 +82,15 @@ class OrderBasket: NSObject {
     }
 }
 
-class OrderVerify: NSObject {
+struct CheckoutBasket {
+    let paymentPageURL: String
+
+    init(json: JSON) {
+        paymentPageURL = json["payment_page_url"].string ?? ""
+    }
+}
+
+struct OrderVerify {
     let status: String
     let number: String
     let currency: String

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -34,6 +34,12 @@ class CourseUpgradeHandler: NSObject {
         }
     }
 
+    var upgradeState: CourseUpgradeState {
+        get {
+            return state
+        }
+    }
+
     var errorMessage: String {
         if case .error (let type, let error) = state {
             guard let error = error as NSError? else { return Strings.CourseUpgrade.FailureAlert.generalErrorMessage }
@@ -183,6 +189,17 @@ class CourseUpgradeHandler: NSObject {
                 self?.state = .complete
             } else {
                 self?.state = .error(type: .verifyReceiptError, error: response.error)
+            }
+        }
+    }
+
+    // Give an option of retry to learner
+    func reverifyPayment() {
+        PaymentManager.shared.purchaseReceipt { [weak self] success, receipt, error in
+            if let receipt = receipt, success {
+                self?.verifyPayment(receipt)
+            } else {
+                self?.state = .error(type: (error?.type ?? .paymentError), error: error?.error)
             }
         }
     }

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -28,15 +28,9 @@ class CourseUpgradeHandler: NSObject {
     private var course: OEXCourse?
     private var basketID: Int = 0
     private var courseSku: String = ""
-    private var state: CourseUpgradeState = .initial {
+    private(set) var state: CourseUpgradeState = .initial {
         didSet {
             completion?(state)
-        }
-    }
-
-    var upgradeState: CourseUpgradeState {
-        get {
-            return state
         }
     }
 

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -79,27 +79,25 @@ class CourseUpgradeHelper: NSObject {
 
         let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: CourseUpgradeHandler.shared.errorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
 
-        if case .error (let type, _) = CourseUpgradeHandler.shared.state {
-            if type == .verifyReceiptError {
-                alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.refreshToRetry, style: .default) {action in
-                    CourseUpgradeHandler.shared.reverifyPayment()
-                }
+        if case .error (let type, _) = CourseUpgradeHandler.shared.state, type == .verifyReceiptError {
+            alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.refreshToRetry, style: .default) { _ in
+                CourseUpgradeHandler.shared.reverifyPayment()
             }
         }
 
         if case .complete = CourseUpgradeHandler.shared.state, completion != nil {
-            alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.refreshToRetry, style: .default) {[weak self] action in
+            alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.refreshToRetry, style: .default) {[weak self] _ in
                 self?.showLoader()
                 self?.completion?()
                 self?.completion = nil
             }
         }
 
-        alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { [weak self] action in
+        alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { [weak self] _ in
             self?.launchEmailComposer(errorMessage: "Error: \(CourseUpgradeHandler.shared.formattedError)")
         }
 
-        alertController.addButton(withTitle: Strings.close, style: .default) { [weak self] action in
+        alertController.addButton(withTitle: Strings.close, style: .default) { [weak self] _ in
             if self?.unlockController.isVisible ?? false {
                 self?.unlockController.removeView() {
                     self?.delegate?.hideAlertAction()

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -17,6 +17,10 @@ struct CourseUpgradeModel {
     let screen: CourseUpgradeScreen
 }
 
+protocol CourseUpgradeHelperDelegate: AnyObject {
+    func hideAlertAction()
+}
+
 class CourseUpgradeHelper: NSObject {
     
     static let courseID = "CourseID"
@@ -24,30 +28,44 @@ class CourseUpgradeHelper: NSObject {
     static let screen = "Screen"
     
     static let shared = CourseUpgradeHelper()
-    
+    private lazy var unlockController = ValuePropUnlockViewContainer()
+    weak var delegate: CourseUpgradeHelperDelegate?
+
     enum CompletionState {
         case fulfillment
         case success(_ courseID: String, _ componentID: String?)
-        case error
+        case error(PurchaseError)
     }
-    
-    var courseUpgradeModel: CourseUpgradeModel?
+
+    private var upgradeModel: CourseUpgradeModel?
+
+    var courseUpgradeModel: CourseUpgradeModel? {
+        get {
+            return upgradeModel
+        }
+    }
         
     private override init() { }
     
-    func handleCourseUpgrade(state: CompletionState, screen: CourseUpgradeScreen) {
+    func handleCourseUpgrade(state: CompletionState, screen: CourseUpgradeScreen, delegate: CourseUpgradeHelperDelegate? = nil) {
+        self.delegate = delegate
         switch state {
         case .fulfillment:
             showLoader()
             break
         case .success(let courseID, let blockID):
-            courseUpgradeModel = CourseUpgradeModel(courseID: courseID, blockID: blockID, screen: screen)
+            upgradeModel = CourseUpgradeModel(courseID: courseID, blockID: blockID, screen: screen)
             NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: CourseUpgradeCompletionNotification), object: nil))
             break
-        case .error:
-            removeLoader(success: false)
+        case .error(let type):
+            removeLoader(success: false, removeView: type != .verifyReceiptError, controller: nil, selector: nil)
             break
         }
+    }
+
+    func resetUpgradeModel() {
+        upgradeModel = nil
+        delegate = nil
     }
     
     func showSuccess() {
@@ -55,43 +73,74 @@ class CourseUpgradeHelper: NSObject {
         topController.showBottomActionSnackBar(message: Strings.CourseUpgrade.successMessage, textSize: .xSmall, autoDismiss: true, duration: 3)
     }
     
-    func showError() {
+    func showError(controller: UIViewController? = nil, selector: Selector? = nil) {
         guard let topController = UIApplication.shared.topMostController() else { return }
+
         let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: CourseUpgradeHandler.shared.errorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
+
+        if case .error (let type, _) = CourseUpgradeHandler.shared.upgradeState {
+            if type == .verifyReceiptError {
+                alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.refreshToRetry, style: .default) {action in
+                    CourseUpgradeHandler.shared.reverifyPayment()
+                }
+            }
+        }
+
+        if case .complete = CourseUpgradeHandler.shared.upgradeState, (controller != nil && selector != nil) {
+            alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.refreshToRetry, style: .default) {[weak self] action in
+                self?.showLoader()
+                controller?.perform(selector)
+            }
+        }
+
         alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { [weak self] action in
             self?.launchEmailComposer(errorMessage: "Error: \(CourseUpgradeHandler.shared.formattedError)")
         }
-        alertController.addButton(withTitle: Strings.close, style: .default) { action in
-            
+
+        alertController.addButton(withTitle: Strings.close, style: .default) { [weak self] action in
+            if self?.unlockController.isVisible ?? false {
+                self?.unlockController.removeView() {
+                    self?.delegate?.hideAlertAction()
+                    self?.resetUpgradeModel()
+                }
+            }
+            else {
+                self?.delegate?.hideAlertAction()
+                self?.resetUpgradeModel()
+            }
         }
     }
     
     func showLoader() {
-        ValuePropUnlockViewContainer.shared.showView()
+        if !unlockController.isVisible {
+            unlockController.showView()
+        }
     }
     
-    func removeLoader(success: Bool? = nil) {
-        courseUpgradeModel = nil
-        
-        if ValuePropUnlockViewContainer.shared.isVisible {
-            ValuePropUnlockViewContainer.shared.removeView() { [weak self] in
+    func removeLoader(success: Bool? = false, removeView: Bool? = false, controller: UIViewController? = nil, selector: Selector? = nil) {
+        if success == true {
+            upgradeModel = nil
+        }
+
+        if unlockController.isVisible, removeView == true {
+            unlockController.removeView() { [weak self] in
                 if let success = success {
                     if success {
                         self?.showSuccess()
                     } else {
-                        self?.showError()
+                        self?.showError(controller: controller, selector: selector)
                     }
                 }
             }
         } else if success == false {
-            showError()
+            showError(controller: controller, selector: selector)
         }
     }
 }
 
 extension CourseUpgradeHelper: MFMailComposeViewControllerDelegate {
     fileprivate func launchEmailComposer(errorMessage: String) {
-        guard let controller = UIApplication.shared.window?.rootViewController else { return }
+        guard let controller = UIApplication.shared.topMostController() else { return }
 
         if !MFMailComposeViewController.canSendMail() {
             UIAlertController().showAlert(withTitle: Strings.emailAccountNotSetUpTitle, message: Strings.emailAccountNotSetUpMessage, onViewController: controller)
@@ -110,7 +159,18 @@ extension CourseUpgradeHelper: MFMailComposeViewControllerDelegate {
     }
 
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        guard let controller = UIApplication.shared.window?.rootViewController else { return }
-        controller.dismiss(animated: true, completion: nil)
+        guard let controller = UIApplication.shared.topMostController() else { return }
+        controller.dismiss(animated: true, completion: { [weak self] in
+            if self?.unlockController.isVisible ?? false {
+                self?.unlockController.removeView(completion: {
+                    self?.delegate?.hideAlertAction()
+                    self?.resetUpgradeModel()
+                })
+            }
+            else {
+                self?.delegate?.hideAlertAction()
+                self?.resetUpgradeModel()
+            }
+        })
     }
 }

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -98,7 +98,7 @@ class CourseUpgradeHelper: NSObject {
         }
 
         alertController.addButton(withTitle: Strings.close, style: .default) { [weak self] _ in
-            if self?.unlockController.isVisible ?? false {
+            if self?.unlockController.isVisible == true {
                 self?.unlockController.removeView() {
                     self?.delegate?.hideAlertAction()
                     self?.resetUpgradeModel()
@@ -162,7 +162,7 @@ extension CourseUpgradeHelper: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         guard let controller = UIApplication.shared.topMostController() else { return }
         controller.dismiss(animated: true, completion: { [weak self] in
-            if self?.unlockController.isVisible ?? false {
+            if self?.unlockController.isVisible == true {
                 self?.unlockController.removeView(completion: {
                     self?.delegate?.hideAlertAction()
                     self?.resetUpgradeModel()

--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -153,6 +153,7 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
     [arguments setSafeObject:@"password" forKey:@"grant_type"];
     [arguments setSafeObject:userName forKey:@"username"];
     [arguments setSafeObject:password forKey:@"password"];
+    [arguments setSafeObject:@"jwt" forKey:@"token_type"];
     return [arguments oex_stringByUsingFormEncoding];
 }
 

--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -153,7 +153,6 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
     [arguments setSafeObject:@"password" forKey:@"grant_type"];
     [arguments setSafeObject:userName forKey:@"username"];
     [arguments setSafeObject:password forKey:@"password"];
-    [arguments setSafeObject:@"jwt" forKey:@"token_type"];
     return [arguments oex_stringByUsingFormEncoding];
 }
 

--- a/Source/PaymentManager.swift
+++ b/Source/PaymentManager.swift
@@ -153,7 +153,11 @@ enum PurchaseError: String {
         }
     }
     
-    private func purchaseReceipt() {
+    func purchaseReceipt(completion: PurchaseCompletionHandler? = nil) {
+        if let completion = completion {
+            self.completion = completion
+        }
+
         storeKit.fetchReceipt(forceRefresh: false) { [weak self] result in
             switch result {
             case .success(let receiptData):

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -197,11 +197,11 @@ class ValuePropComponentView: UIView {
 
         let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: Strings.CourseUpgrade.FailureAlert.priceFetchErrorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
 
-        alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.coursePriceError) { [weak self] action in
+        alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.coursePriceError) { [weak self] _ in
             self?.fetchCoursePrice()
         }
 
-        alertController.addButton(withTitle: Strings.cancel, style: .default) { [weak self] action in
+        alertController.addButton(withTitle: Strings.cancel, style: .default) { [weak self] _ in
             self?.upgradeButton.stopShimmerEffect()
             self?.upgradeButton.updateVisibility(visible: false)
         }

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -195,7 +195,7 @@ class ValuePropComponentView: UIView {
     private func showCoursePriceErrorAlert() {
         guard let topController = UIApplication.shared.topMostController() else { return }
 
-        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: CourseUpgradeHandler.shared.errorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
+        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: Strings.CourseUpgrade.FailureAlert.priceFetchErrorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
 
         alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.coursePriceError) { [weak self] action in
             self?.fetchCoursePrice()

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -186,10 +186,24 @@ class ValuePropComponentView: UIView {
                     self?.upgradeButton.stopShimmerEffect()
                     self?.upgradeButton.setPrice(price)
                 } else {
-                    self?.upgradeButton.stopShimmerEffect()
-                    self?.upgradeButton.updateVisibility(visible: false)
+                    self?.showCoursePriceErrorAlert()
                 }
             }
+        }
+    }
+
+    private func showCoursePriceErrorAlert() {
+        guard let topController = UIApplication.shared.topMostController() else { return }
+
+        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: CourseUpgradeHandler.shared.errorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
+
+        alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.coursePriceError) { [weak self] action in
+            self?.fetchCoursePrice()
+        }
+
+        alertController.addButton(withTitle: Strings.cancel, style: .default) { [weak self] action in
+            self?.upgradeButton.stopShimmerEffect()
+            self?.upgradeButton.updateVisibility(visible: false)
         }
     }
 

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -79,9 +79,12 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         
         addObserver()
         configureView()
-        
+        fetchCoursePrice()
+    }
+
+    private func fetchCoursePrice() {
         guard let courseSku = UpgradeSKUManager.shared.courseSku(for: course) else { return }
-        
+
         DispatchQueue.main.async { [weak self] in
             self?.upgradeButton.startShimeringEffect()
             PaymentManager.shared.productPrice(courseSku) { [weak self] price in
@@ -89,10 +92,25 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
                     self?.upgradeButton.stopShimmerEffect()
                     self?.upgradeButton.setPrice(price)
                 } else {
-                    self?.upgradeButton.stopShimmerEffect()
-                    self?.upgradeButton.isHidden = true
+                    self?.showCoursePriceErrorAlert()
                 }
             }
+        }
+    }
+
+    private func showCoursePriceErrorAlert() {
+        guard let topController = UIApplication.shared.topMostController() else { return }
+
+        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: CourseUpgradeHandler.shared.errorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
+
+
+        alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.priceFetchError) { [weak self] action in
+            self?.fetchCoursePrice()
+        }
+
+        alertController.addButton(withTitle: Strings.cancel, style: .default) { [weak self] action in
+            self?.upgradeButton.stopShimmerEffect()
+            self?.upgradeButton.isHidden = true
         }
     }
     
@@ -174,15 +192,8 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
             case .error(let type, _):
                 self?.enableUserInteraction(enable: true)
                 self?.upgradeButton.stopAnimating()
-
-                if case .verifyReceiptError = type {
-                    self?.dismiss(animated: true) { [weak self] in
-                        self?.courseUpgradeHelper.handleCourseUpgrade(state: .error, screen: self?.screen ?? .none)
-                    }
-                }
-                else {
-                    self?.courseUpgradeHelper.handleCourseUpgrade(state: .error, screen: self?.screen ?? .none)
-                }
+                let delegate = (type == .verifyReceiptError) ? self : nil
+                self?.courseUpgradeHelper.handleCourseUpgrade(state: .error(type), screen: self?.screen ?? .none, delegate: delegate)
                 break
             default:
                 break
@@ -210,5 +221,11 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
 extension ValuePropDetailViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         return isModalDismissable
+    }
+}
+
+extension ValuePropDetailViewController: CourseUpgradeHelperDelegate {
+    func hideAlertAction() {
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -101,7 +101,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
     private func showCoursePriceErrorAlert() {
         guard let topController = UIApplication.shared.topMostController() else { return }
 
-        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: CourseUpgradeHandler.shared.errorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
+        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: Strings.CourseUpgrade.FailureAlert.priceFetchErrorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
 
 
         alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.priceFetchError) { [weak self] action in

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -104,11 +104,11 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: Strings.CourseUpgrade.FailureAlert.priceFetchErrorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
 
 
-        alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.priceFetchError) { [weak self] action in
+        alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.priceFetchError) { [weak self] _ in
             self?.fetchCoursePrice()
         }
 
-        alertController.addButton(withTitle: Strings.cancel, style: .default) { [weak self] action in
+        alertController.addButton(withTitle: Strings.cancel, style: .default) { [weak self] _ in
             self?.upgradeButton.stopShimmerEffect()
             self?.upgradeButton.isHidden = true
         }

--- a/Source/ValuePropUnlockViewContainer.swift
+++ b/Source/ValuePropUnlockViewContainer.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class ValuePropUnlockViewContainer: NSObject {
-    static let shared = ValuePropUnlockViewContainer()
     
     private let delay: TimeInterval = 3
     private var container: UIView?
@@ -17,7 +16,7 @@ class ValuePropUnlockViewContainer: NSObject {
     
     var isVisible: Bool { return container != nil }
     
-    private override init() { }
+    override init() { }
     
     private var controller: ValuePropUnlockViewController?
     
@@ -57,6 +56,9 @@ class ValuePropUnlockViewContainer: NSObject {
         func dismiss() {
             container?.subviews.forEach { $0.removeFromSuperview() }
             container?.removeFromSuperview()
+            controller?.removeFromParent()
+            container = nil
+            controller = nil
             shouldDismiss.unsubscribe(observer: self)
             NotificationCenter.default.removeObserver(self)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -404,6 +404,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -405,7 +405,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -388,6 +388,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -389,7 +389,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -389,7 +389,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -388,6 +388,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Get support e-mail subject in the payment error flow*/
 "COURSE_UPGRADE.GET_SUPPORT_EMAIL_SUBJECT"="Error upgrading course in app";
 /* Button text for cancelling any action */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -389,7 +389,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -388,6 +388,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /* Button text for cancelling any action */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -388,6 +388,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -389,7 +389,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -396,6 +396,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -397,7 +397,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -386,6 +386,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -387,7 +387,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -389,6 +389,14 @@ Se você não conseguir acompanhar tudo nas datas sugeridas, você poderá ajust
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -390,7 +390,7 @@ Se você não conseguir acompanhar tudo nas datas sugeridas, você poderá ajust
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -388,6 +388,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -389,7 +389,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -383,7 +383,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -382,6 +382,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -385,7 +385,7 @@
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
 /*App is not able to fetch the price from the app store*/
-"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR_MESSAGE"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Try again button on the failure alert to re-fetch the price from the app store*/
 "COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
 /*Try again button on the failure alert to retry the course upgrade after the successful payment*/

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -384,6 +384,14 @@
 "COURSE_UPGRADE.FAILURE_ALERT.PAYMENT_NOT_PROCESSED"="Your payment could not be processed at this time. Please try again. For additional help, reach out to Support.";
 /*The native payment is complete but an error errored while marking the course verified*/
 "COURSE_UPGRADE.FAILURE_ALERT.COURSE_NOT_FULLFILLED"="Something happened when we tried to update your course experience. If this error continues, reach out to Support for help.";
+/*App is not able to fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
+/*Try again button on the failure alert to re-fetch the price from the app store*/
+"COURSE_UPGRADE.FAILURE_ALERT.PRICE_FETCH_ERROR"="Try again";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.REFRESH_TO_RETRY"="Refresh to retry";
+/*Try again button on the failure alert to retry the course upgrade after the successful payment*/
+"COURSE_UPGRADE.FAILURE_ALERT.COURSE_PRICE_ERROR"="Your request could not be completed at this time. If this error continues, please reach out to Support.";
 /*Course upgrade failure alert get help button title*/
 "COURSE_UPGRADE.FAILURE_ALERT_GET_HELP"="Get help";
 /*Get support e-mail subject in the payment error flow*/


### PR DESCRIPTION

### Description

[LEARNER-8798](https://openedx.atlassian.net/browse/LEARNER-8798)

1. Give an option of Retry to the learner as per the [figma](https://www.figma.com/file/SFpqDv2FVf2RRV56ATEakH/Payments?node-id=3061%3A4177) to update the content if the failure occurs after the payment. Add a new button  Refresh to retry in the failure alert that will appear in case of an error after the successful payment. This can happen in the following cases:

  - executeAPI failed to verify the payment and update the course mode to verified.
  
  - execute API successfully verified the payment and updated the course mode to verified but:
  
  - enrollment API fails to get the updated enrollments from the server.
  
  - blocks API fails to get the updated data course data from the server.

2. Give an option of Retry to fetch the price details of the course if it failed to get the price details on the first try according to the [figma](https://www.figma.com/file/SFpqDv2FVf2RRV56ATEakH/Payments?node-id=3109%3A4247).
