### PR TITLE
[feat] keep loader while waiting for my payment success notification

### DIFF
--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -214,6 +214,7 @@ extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
             
             switch status {
             case .verify:
+                upgradeView.stopAnimating()
                 self?.courseUpgradeHelper.handleCourseUpgrade(state: .fulfillment, screen: .courseUnit)
                 break
             case .complete:

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -176,10 +176,8 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
             self?.enableUserInteraction(enable: false)
             
             switch status {
-            case .payment:
-                self?.upgradeButton.stopAnimating()
-                break
             case .verify:
+                self?.upgradeButton.stopAnimating()
                 self?.courseUpgradeHelper.handleCourseUpgrade(state: .fulfillment, screen: self?.screen ?? .none)
                 break
             case .complete:


### PR DESCRIPTION
### Description

[LEARNER-8855](https://openedx.atlassian.net/browse/LEARNER-8855)

Leave the button loader animation in the background while the OS takes over the UI to complete payment.
