### PR TITLE
[feat] show dialog when opening a URL in an external browser from the "Discover"

### DIFF
--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -287,8 +287,13 @@ extension DiscoveryWebViewHelper: WKNavigationDelegate {
             let capturedLink = navigationAction.navigationType == .linkActivated
             let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
             if let url = request.url, outsideLink || capturedLink {
-                if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                guard let contrller = delegate?.webViewContainingController() else { return }
+                
+                let alertController = UIAlertController().showAlert(withTitle: Strings.leavingAppToExternalBrowserTitle, message: Strings.leavingAppToExternalBrowserMessage(platformName: environment.config.platformName()), cancelButtonTitle: Strings.cancel, onViewController: contrller) { _, _, _ in }
+                alertController.addButton(withTitle: Strings.continueButtonTitle, style: .default) { _ in
+                    if UIApplication.shared.canOpenURL(url) {
+                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    }
                 }
                 decisionHandler(.cancel)
             } else {

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "BY_AUTHOR" = "من قبل {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "من قبل {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="تهانينا!";
 /* Course completion subtitle */
@@ -1108,3 +1110,7 @@
 "YES"="تأكيد";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="The video could not loaded, invalid url.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 "BY_AUTHOR" = "Von {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "von {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="Glückwunsch!";
 /* Course completion subtitle */
@@ -1044,3 +1046,7 @@
 "YES"="Ja";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="Das Video konnte nicht geladen werden, ungültige URL.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 "BY_AUTHOR" = "By {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "by {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="CONGRATULATIONS!";
 /* Course completion subtitle */
@@ -1046,3 +1048,7 @@
 "YES"="Yes";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="The video could not loaded, invalid url.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 "BY_AUTHOR" = "Por {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "por {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="FELICITACIONES!";
 /* Course completion subtitle */
@@ -1050,3 +1052,7 @@
 "YES"="Si";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="El video no se pudo cargar, URL no válida.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 "BY_AUTHOR" = "Par {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "par {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="FELICITATIONS !";
 /* Course completion subtitle */
@@ -1044,4 +1046,7 @@
 "YES"="Oui";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="La vidéo n'a pas pu être chargée, URL invalide.";
-
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -256,6 +256,8 @@
 "BY_AUTHOR" = "נכתב על ידי {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "נכתב על ידי {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="מזל טוב!";
 /* Course completion subtitle */
@@ -1070,3 +1072,7 @@
 "YES"="כן";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="לא ניתן היה לטעון את הווידאו כתובת אתר לא חוקית.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -244,6 +244,8 @@
 "BY_AUTHOR" = "{author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "{author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="おめでとうございます！";
 /* Course completion subtitle */
@@ -1031,3 +1033,7 @@
 "YES"="はい";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="The video could not loaded, invalid url.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 "BY_AUTHOR" = "Por {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "por {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="PARABÉNS!";
 /* Course completion subtitle */
@@ -1045,3 +1047,7 @@ Se você não conseguir acompanhar tudo nas datas sugeridas, você poderá ajust
 "YES"="Sim";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="O vídeo não pôde ser carregado, o URL inválido.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -248,6 +248,8 @@
 "BY_AUTHOR" = "{author_name} Tarafından";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "{author_name} tarafından";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="TEBRİKLER!";
 /* Course completion subtitle */
@@ -1044,3 +1046,7 @@
 "YES"="Evet";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="Video yüklenemedi, geçersiz URL.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -244,6 +244,8 @@
 "BY_AUTHOR" = "Bởi {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "bởi {author_name}";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="CHÚC MỪNG!";
 /* Course completion subtitle */
@@ -1026,3 +1028,7 @@
 "YES"="Có";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="The video could not loaded, invalid url.";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -244,6 +244,8 @@
 "BY_AUTHOR" = "{author_name}作";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "{author_name}作";
+/* Continue */
+"CONTINUE_BUTTON_TITLE"="Continue";
 /* Course completion title */
 "CERTIFICATES.COURSE_COMPLETION_TITLE"="恭喜！";
 /* Course completion subtitle */
@@ -1028,3 +1030,7 @@
 "YES"="是";
 /* Invalid youtube url error message */
 "YOUTUBE_INVALID_URL_ERROR"="視頻無法加載，無效的網址。";
+/* Title for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_TITLE"="Leaving the app";
+/* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */
+"LEAVING_APP_TO_EXTERNAL_BROWSER_MESSAGE"="You are now leaving the {platform_name} app and opening a browser.";


### PR DESCRIPTION
### Description

[LEARNER-8833](https://openedx.atlassian.net/browse/LEARNER-8833)

When user taps on external link, a confirmation dialog is shown before opening url to external browser.

### How to test this PR

- [ ] When tapping a link that should bring the user out of the app and into an external browser, the user is presented with an alert as shown in the Figma file
- [ ] Tapping “Cancel” on the alert closes the alert with no further action
- [ ] Tapping “Continue”  closes the alert and brings the user to the desired link in the external browser
- [ ] The alert is not open when the user returns to the edX app
- [ ] Experience is the same from both the “Discover” tab and the pre-login search
