### PR TITLE
[fix] calendar sync toggle overlapping with text fix

### DIFF
--- a/Source/CourseDatesHeaderView.swift
+++ b/Source/CourseDatesHeaderView.swift
@@ -247,7 +247,7 @@ class CourseDatesHeaderView: UITableViewHeaderFooterView {
         
         syncToCalenderLabel.snp.remakeConstraints { make in
             make.leading.equalTo(arrowImageView.snp.trailing).offset(StandardHorizontalMargin/2)
-            make.trailing.equalTo(syncSwitch.snp.leading).inset(StandardHorizontalMargin)
+            make.trailing.lessThanOrEqualTo(syncSwitch.snp.leading).inset(StandardHorizontalMargin)
             make.centerY.equalTo(arrowImageView)
         }
         


### PR DESCRIPTION
### Description

[LEARNER-8617](https://2u-internal.atlassian.net/browse/LEARNER-8617)

The Calendar toggle overlaps with the title text for RTL languages

### How to test this PR
- [ ] Calendar sync switch should not overlap in LTR languages 
- [ ] Calendar sync switch should not overlap in RTL languages 
