### PR TITLE
[chore] Sign Up With Apple Improvements

### DIFF
--- a/Source/AppleSocial.swift
+++ b/Source/AppleSocial.swift
@@ -39,7 +39,7 @@ typealias AppleLoginCompletionHandler = (OEXRegisteringUserDetails?, _ accessTok
         authorizationController.performRequests()
     }
 
-    @objc func saveUserName() -> String {
+    @objc func savedUserName() -> String {
         return KeychainSwift().get(appleNameKey) ?? ""
     }
 }
@@ -69,7 +69,7 @@ extension AppleSocial: ASAuthorizationControllerDelegate {
         }
 
         if firstName.isEmpty && lastName.isEmpty {
-            name = saveUserName()
+            name = savedUserName()
         }
 
         let userDetails = OEXRegisteringUserDetails()

--- a/Source/AppleSocial.swift
+++ b/Source/AppleSocial.swift
@@ -7,15 +7,18 @@
 //
 
 import AuthenticationServices
+import KeychainSwift
 
 private let errorDomain = "AppleSocial"
+private let appleNameKey = "APPLE_SIGNUP_NAME_KEY"
+
 
 typealias AppleLoginCompletionHandler = (OEXRegisteringUserDetails?, _ accessToken: String?, Error?) -> Void
 
 
-class AppleSocial: NSObject {
+@objc class AppleSocial: NSObject {
 
-    static let shared = AppleSocial()
+    @objc static let shared = AppleSocial()
     private var completionHandler: AppleLoginCompletionHandler?
 
     private override init() {
@@ -35,6 +38,10 @@ class AppleSocial: NSObject {
         authorizationController.presentationContextProvider = self
         authorizationController.performRequests()
     }
+
+    @objc func saveUserName() -> String {
+        return KeychainSwift().get(appleNameKey) ?? ""
+    }
 }
 
 extension AppleSocial: ASAuthorizationControllerDelegate {
@@ -50,12 +57,23 @@ extension AppleSocial: ASAuthorizationControllerDelegate {
             return
         }
 
-        let firstName = credentials.fullName?.givenName
-        let lastName = credentials.fullName?.familyName
+        let firstName = credentials.fullName?.givenName ?? ""
+        let lastName = credentials.fullName?.familyName ?? ""
         let email = credentials.email ?? ""
 
+        var name = "\(firstName) \(lastName)"
+        if !name.isEmpty && name != " " {
+            // Save data in keychain because apple won't return data on 2nd request
+            // if sign up was not completed
+            KeychainSwift().set(name, forKey: appleNameKey)
+        }
+
+        if firstName.isEmpty && lastName.isEmpty {
+            name = saveUserName()
+        }
+
         let userDetails = OEXRegisteringUserDetails()
-        userDetails.name = "\(firstName ?? "") \(lastName ?? "")"
+        userDetails.name = name
         userDetails.email = email
 
         if let data = credentials.identityToken, let code = String(data: data, encoding: .utf8) {
@@ -98,7 +116,6 @@ extension AppleSocial: ASAuthorizationControllerDelegate {
       let segments = jwt.components(separatedBy: ".")
       return try decodeJWTPart(segments[1])
     }
-
 }
 
 extension AppleSocial: ASAuthorizationControllerPresentationContextProviding {

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -289,7 +289,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
             }
         }
         else if ([[fieldController field].name isEqualToString:@"name"] && [_externalProvider.displayName isEqualToString:@"Apple"])  {
-            [fieldController setValue:[[AppleSocial shared] saveUserName]];
+            [fieldController setValue:[[AppleSocial shared] savedUserName]];
         }
     }
 }

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -288,6 +288,9 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
                 self.email = fieldController.field.defaultValue;
             }
         }
+        else if ([[fieldController field].name isEqualToString:@"name"] && [_externalProvider.displayName isEqualToString:@"Apple"])  {
+            [fieldController setValue:[[AppleSocial shared] saveUserName]];
+        }
     }
 }
 


### PR DESCRIPTION
### Description

[LEARNER-8951](https://2u-internal.atlassian.net/browse/LEARNER-8951)

Currently, subsequent logins to the app using Sign In with Apple with the same account do not share any user info and will only return a user identifier in the ASAuthorizationAppleIDCredential. Due to this we are getting no response in the Full Name field which is failing the App Review on App Store Connect.

It is recommended that we securely cache the initial ASAuthorizationAppleIDCredential containing the user info until we can validate that an account has successfully been created on your server.

### Notes

### How to test this PR
