### PR TITLE
[fix] Fix webkit crash in course discovery

### DIFF
--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -200,7 +200,10 @@ extension DiscoveryWebViewHelper: WKNavigationDelegate {
             let capturedLink = navigationAction.navigationType == .linkActivated
             let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
             if let url = request.url, outsideLink || capturedLink {
-                guard let contrller = delegate?.webViewContainingController(), UIApplication.shared.canOpenURL(url) else { return }
+                guard let contrller = delegate?.webViewContainingController(), UIApplication.shared.canOpenURL(url) else {
+                    decisionHandler(.cancel)
+                    return
+                }
                 environment.analytics.trackEvent(with: .DiscoverExternalLinkOpenAlert, name: .DiscoverExternalLinkOpenAlert, category: .Discovery, info: ["url" : url.absoluteString])
                 let alertController = UIAlertController().showAlert(withTitle: Strings.leavingAppTitle, message: Strings.leavingAppMessage(platformName: environment.config.platformName()), cancelButtonTitle: nil, onViewController: contrller) { _, _, _ in }
 


### PR DESCRIPTION
### Description

[LEARNER-8972](https://2u-internal.atlassian.net/browse/LEARNER-8972)

After the release of our new discovery experience, the WebKit crash is occurring at high velocity in certain scenarios. More details on the crash can be found in the link below:

### Notes

The crash is reproducible only in dev environment. To reproducible the crash `return`  without taking any decision from the delegate method `func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void)` 

