### PR TITLE
[chore] add SDN prompt for user before payment process

### DIFF
--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -221,6 +221,9 @@ extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
             self?.enableUserInteraction(enable: false)
             
             switch status {
+            case .sdn:
+                self?.courseUpgradeHelper.handleCourseUpgrade(upgradeHadler: upgradeHandler, state: .sdn)
+                break
             case .payment:
                 self?.courseUpgradeHelper.handleCourseUpgrade(upgradeHadler: upgradeHandler, state: .payment)
                 break

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -147,13 +147,18 @@ class CourseUpgradeHandler: NSObject {
     
     private func showSDNprompt(completion: @escaping (Bool) -> ()) {
         guard let controller = UIApplication.shared.topMostController() else { return }
-        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.Sdn.Prompt.title, message: Strings.CourseUpgrade.Sdn.Prompt.message, cancelButtonTitle: nil, onViewController: controller) { _, _, _ in }
-        alertController.addButton(withTitle: Strings.cancel) { _ in
-            completion(false)
+        
+        let alert = UIAlertController().alert(withTitle: Strings.CourseUpgrade.Sdn.Prompt.title, message: Strings.CourseUpgrade.Sdn.Prompt.message, cancelButtonTitle: Strings.cancel) { controller, action, buttonIndex in
+            if buttonIndex == controller.cancelButtonIndex {
+                completion(false)
+            }
         }
-        alertController.addButton(withTitle: Strings.ok) { _ in
+        
+        alert.addButton(withTitle: Strings.ok) { _ in
             completion(true)
         }
+        
+        controller.present(alert, animated: true)
     }
     
     private func upgrade() {

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -135,16 +135,10 @@ class CourseUpgradeHandler: NSObject {
         
         state = .initial
         
-        showSDNpromptIfNeeded { [weak self] in
-            self?.upgrade()
-        }
-    }
-    
-    private func showSDNpromptIfNeeded(completion: @escaping () -> ()) {
         showSDNprompt { [weak self] success in
             if success {
                 self?.state = .sdn
-                completion()
+                self?.upgrade()
             } else {
                 self?.state = .error(type: .sdnError, error: self?.error(message: "user does not allow sdn check"))
             }
@@ -153,7 +147,7 @@ class CourseUpgradeHandler: NSObject {
     
     private func showSDNprompt(completion: @escaping (Bool) -> ()) {
         guard let controller = UIApplication.shared.topMostController() else { return }
-        let alertController = UIAlertController().showAlert(withTitle: "SDN", message: "SDN message body", cancelButtonTitle: nil, onViewController: controller) { _, _, _ in }
+        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.Sdn.Prompt.title, message: Strings.CourseUpgrade.Sdn.Prompt.message, cancelButtonTitle: nil, onViewController: controller) { _, _, _ in }
         alertController.addButton(withTitle: Strings.cancel) { _ in
             completion(false)
         }

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -138,7 +138,7 @@ class CourseUpgradeHandler: NSObject {
         showSDNprompt { [weak self] success in
             if success {
                 self?.state = .sdn
-                self?.proceedWithPayment()
+                self?.proceedWithUpgrade()
             } else {
                 self?.state = .error(type: .sdnError, error: self?.error(message: "user does not allow sdn check"))
             }
@@ -161,7 +161,7 @@ class CourseUpgradeHandler: NSObject {
         controller.present(alert, animated: true)
     }
     
-    private func proceedWithPayment() {
+    private func proceedWithUpgrade() {
         guard let course = self.course,
               let coursePurchaseSku = course.sku else {
                   state = .error(type: .generalError, error: error(message: "course sku is missing"))

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -138,7 +138,7 @@ class CourseUpgradeHandler: NSObject {
         showSDNprompt { [weak self] success in
             if success {
                 self?.state = .sdn
-                self?.upgrade()
+                self?.proceedWithPayment()
             } else {
                 self?.state = .error(type: .sdnError, error: self?.error(message: "user does not allow sdn check"))
             }
@@ -161,7 +161,7 @@ class CourseUpgradeHandler: NSObject {
         controller.present(alert, animated: true)
     }
     
-    private func upgrade() {
+    private func proceedWithPayment() {
         guard let course = self.course,
               let coursePurchaseSku = course.sku else {
                   state = .error(type: .generalError, error: error(message: "course sku is missing"))

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -104,7 +104,7 @@ class CourseUpgradeHelper: NSObject {
             startTime = CFAbsoluteTimeGetCurrent()
             break
         case .sdn:
-            environment?.analytics.trackSDN(accept: true, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
+            trackSDNanlytics(status: true)
             break
         case .payment:
             paymentStartTime = CFAbsoluteTimeGetCurrent()
@@ -128,7 +128,7 @@ class CourseUpgradeHelper: NSObject {
             if type == .paymentError {
                 environment?.analytics.trackCourseUpgradePaymentError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, paymentError: upgradeHadler.formattedError)
             } else if type == .sdnError {
-                environment?.analytics.trackSDN(accept: false, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
+                trackSDNanlytics(status: false)
             }
 
             environment?.analytics.trackCourseUpgradeError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, upgradeError: upgradeHadler.formattedError)
@@ -136,6 +136,10 @@ class CourseUpgradeHelper: NSObject {
             removeLoader(success: false, removeView: type != .verifyReceiptError)
             break
         }
+    }
+    
+    private func trackSDNanlytics(status: Bool) {
+        environment?.analytics.trackSDN(accept: status, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
     }
     
     func showSuccess() {

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -104,7 +104,7 @@ class CourseUpgradeHelper: NSObject {
             startTime = CFAbsoluteTimeGetCurrent()
             break
         case .sdn:
-            environment?.analytics.trackSDN(status: true, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
+            environment?.analytics.trackSDN(accept: true, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
             break
         case .payment:
             paymentStartTime = CFAbsoluteTimeGetCurrent()
@@ -128,7 +128,7 @@ class CourseUpgradeHelper: NSObject {
             if type == .paymentError {
                 environment?.analytics.trackCourseUpgradePaymentError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, paymentError: upgradeHadler.formattedError)
             } else if type == .sdnError {
-                environment?.analytics.trackSDN(status: false, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
+                environment?.analytics.trackSDN(accept: false, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
             }
 
             environment?.analytics.trackCourseUpgradeError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, upgradeError: upgradeHadler.formattedError)

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -104,7 +104,7 @@ class CourseUpgradeHelper: NSObject {
             startTime = CFAbsoluteTimeGetCurrent()
             break
         case .sdn:
-            trackSDNanlytics(status: true)
+            trackSDNanlytics(allowed: true)
             break
         case .payment:
             paymentStartTime = CFAbsoluteTimeGetCurrent()
@@ -128,7 +128,7 @@ class CourseUpgradeHelper: NSObject {
             if type == .paymentError {
                 environment?.analytics.trackCourseUpgradePaymentError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, paymentError: upgradeHadler.formattedError)
             } else if type == .sdnError {
-                trackSDNanlytics(status: false)
+                trackSDNanlytics(allowed: false)
             }
 
             environment?.analytics.trackCourseUpgradeError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, upgradeError: upgradeHadler.formattedError)
@@ -138,8 +138,8 @@ class CourseUpgradeHelper: NSObject {
         }
     }
     
-    private func trackSDNanlytics(status: Bool) {
-        environment?.analytics.trackSDN(accept: status, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
+    private func trackSDNanlytics(allowed: Bool) {
+        environment?.analytics.trackSDN(accept: allowed, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
     }
     
     func showSuccess() {

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -133,7 +133,7 @@ class CourseUpgradeHelper: NSObject {
 
             environment?.analytics.trackCourseUpgradeError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, upgradeError: upgradeHadler.formattedError)
 
-            removeLoader(success: false, removeView: type != .verifyReceiptError)
+            removeLoader(success: false, removeView: type != .verifyReceiptError, shouldShowError: type != .sdnError)
             break
         }
     }
@@ -221,22 +221,22 @@ class CourseUpgradeHelper: NSObject {
         }
     }
     
-    func removeLoader(success: Bool? = false, removeView: Bool? = false, completion: (()-> ())? = nil) {
+    func removeLoader(success: Bool? = false, removeView: Bool? = false, shouldShowError: Bool = true, completion: (()-> ())? = nil) {
         self.completion = completion
         if success == true {
             courseUpgradeModel = nil
         }
-
+        
         if unlockController.isVisible, removeView == true {
             unlockController.removeView() { [weak self] in
                 self?.courseUpgradeModel = nil
                 if success == true {
                     self?.showSuccess()
-                } else {
+                } else if shouldShowError {
                     self?.showError()
                 }
             }
-        } else if success == false {
+        } else if success == false, shouldShowError {
             showError()
         }
     }

--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -35,6 +35,7 @@ class CourseUpgradeHelper: NSObject {
 
     enum CompletionState {
         case initial
+        case sdn
         case payment
         case fulfillment
         case success(_ courseID: String, _ componentID: String?)
@@ -102,6 +103,9 @@ class CourseUpgradeHelper: NSObject {
         case .initial:
             startTime = CFAbsoluteTimeGetCurrent()
             break
+        case .sdn:
+            environment?.analytics.trackSDN(status: true, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
+            break
         case .payment:
             paymentStartTime = CFAbsoluteTimeGetCurrent()
             break
@@ -123,6 +127,8 @@ class CourseUpgradeHelper: NSObject {
         case .error(let type, _):
             if type == .paymentError {
                 environment?.analytics.trackCourseUpgradePaymentError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, paymentError: upgradeHadler.formattedError)
+            } else if type == .sdnError {
+                environment?.analytics.trackSDN(status: false, courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen)
             }
 
             environment?.analytics.trackCourseUpgradeError(courseID: courseID ?? "", blockID: blockID ?? "", pacing: pacing ?? "", coursePrice: coursePrice ?? "", screen: screen, upgradeError: upgradeHadler.formattedError)

--- a/Source/OEXAnalytics+CourseUpgrade.swift
+++ b/Source/OEXAnalytics+CourseUpgrade.swift
@@ -23,6 +23,23 @@ extension OEXAnalytics {
 
         trackEvent(event, forComponent: nil, withInfo: info)
     }
+    
+    func trackSDN(status: Bool, courseID: String, blockID: String? = nil, pacing: String, coursePrice: String, screen: CourseUpgradeScreen) {
+        let event = OEXAnalyticsEvent()
+        event.displayName = AnalyticsDisplayName.CourseUpgradePaymentTime.rawValue
+        event.name = AnalyticsEventName.CourseUpgradePaymentTime.rawValue
+        event.category = AnalyticsCategory.InAppPurchases.rawValue
+        
+        let info = [
+            AnalyticsEventDataKey.Pacing.rawValue: pacing,
+            key_course_id: courseID,
+            AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.Price.rawValue: coursePrice,
+        ]
+
+        trackEvent(event, forComponent: nil, withInfo: info)
+    }
 
     func trackCourseUpgradePaymentTime(courseID: String, blockID: String? = nil, pacing: String, coursePrice: String, screen: CourseUpgradeScreen, elapsedTime: Int) {
         let event = OEXAnalyticsEvent()

--- a/Source/OEXAnalytics+CourseUpgrade.swift
+++ b/Source/OEXAnalytics+CourseUpgrade.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 extension OEXAnalytics {
-    private enum SDNaction: String {
+    private enum SDNAction: String {
         case accept
         case cancel
     }
@@ -31,12 +31,12 @@ extension OEXAnalytics {
     
     func trackSDN(accept: Bool, courseID: String, blockID: String? = nil, pacing: String, coursePrice: String, screen: CourseUpgradeScreen) {
         let event = OEXAnalyticsEvent()
-        event.displayName = AnalyticsDisplayName.SDNpromptAction.rawValue
-        event.name = AnalyticsEventName.SDNprompt.rawValue
+        event.displayName = AnalyticsDisplayName.SDNPromptAction.rawValue
+        event.name = AnalyticsEventName.SDNPrompt.rawValue
         event.category = AnalyticsCategory.InAppPurchases.rawValue
         
         let info = [
-            AnalyticsEventDataKey.Action.rawValue: accept ? SDNaction.accept.rawValue : SDNaction.cancel.rawValue,
+            AnalyticsEventDataKey.Action.rawValue: accept ? SDNAction.accept.rawValue : SDNAction.cancel.rawValue,
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",

--- a/Source/OEXAnalytics+CourseUpgrade.swift
+++ b/Source/OEXAnalytics+CourseUpgrade.swift
@@ -31,7 +31,7 @@ extension OEXAnalytics {
     
     func trackSDN(accept: Bool, courseID: String, blockID: String? = nil, pacing: String, coursePrice: String, screen: CourseUpgradeScreen) {
         let event = OEXAnalyticsEvent()
-        event.displayName = AnalyticsDisplayName.SDNprompt.rawValue
+        event.displayName = AnalyticsDisplayName.SDNpromptAction.rawValue
         event.name = AnalyticsEventName.SDNprompt.rawValue
         event.category = AnalyticsCategory.InAppPurchases.rawValue
         

--- a/Source/OEXAnalytics+CourseUpgrade.swift
+++ b/Source/OEXAnalytics+CourseUpgrade.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 extension OEXAnalytics {
+    private enum SDNaction: String {
+        case accept
+        case cancel
+    }
+    
     func trackUpgradeNow(with courseID: String, blockID: String? = nil, pacing: String, screenName: CourseUpgradeScreen, coursePrice: String) {
         let event = OEXAnalyticsEvent()
         event.displayName = AnalyticsDisplayName.UpgradeNowClicked.rawValue
@@ -24,13 +29,14 @@ extension OEXAnalytics {
         trackEvent(event, forComponent: nil, withInfo: info)
     }
     
-    func trackSDN(status: Bool, courseID: String, blockID: String? = nil, pacing: String, coursePrice: String, screen: CourseUpgradeScreen) {
+    func trackSDN(accept: Bool, courseID: String, blockID: String? = nil, pacing: String, coursePrice: String, screen: CourseUpgradeScreen) {
         let event = OEXAnalyticsEvent()
-        event.displayName = AnalyticsDisplayName.CourseUpgradePaymentTime.rawValue
-        event.name = AnalyticsEventName.CourseUpgradePaymentTime.rawValue
+        event.displayName = AnalyticsDisplayName.SDNprompt.rawValue
+        event.name = AnalyticsEventName.SDNprompt.rawValue
         event.category = AnalyticsCategory.InAppPurchases.rawValue
         
         let info = [
+            AnalyticsEventDataKey.Action.rawValue: accept ? SDNaction.accept.rawValue : SDNaction.cancel.rawValue,
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -94,7 +94,7 @@ public enum AnalyticsDisplayName : String {
     case CourseUpgradeErrorAction = "Payments: Error Alert Action"
     case DiscoverExternalLinkOpenAlert = "Discovery: External Link Opening Alert"
     case DiscoverExternalLinkOpenAlertAction = "Discovery: External Link Opening Alert Action"
-    case SDNpromptAction = "Payments: SDN Prompt Action"
+    case SDNPromptAction = "Payments: SDN Prompt Action"
 }
 
 public enum AnalyticsEventName: String {
@@ -177,7 +177,7 @@ public enum AnalyticsEventName: String {
     case CourseUpgradeErrorAction = "edx.bi.app.payments.error_alert_action"
     case DiscoverExternalLinkOpenAlert = "edx.bi.app.discovery.external_link.opening.alert"
     case DiscoverExternalLinkOpenAlertAction = "edx.bi.app.discovery.external_link.opening.alert_action"
-    case SDNprompt = "edx.bi.app.payments.sdn_prompt_action"
+    case SDNPrompt = "edx.bi.app.payments.sdn_prompt_action"
 }
 
 public enum AnalyticsScreenName: String {

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -94,7 +94,7 @@ public enum AnalyticsDisplayName : String {
     case CourseUpgradeErrorAction = "Payments: Error Alert Action"
     case DiscoverExternalLinkOpenAlert = "Discovery: External Link Opening Alert"
     case DiscoverExternalLinkOpenAlertAction = "Discovery: External Link Opening Alert Action"
-    case SDNprompt = "Payments: SDN Prompt"
+    case SDNprompt = "Payments: SDN Prompt Action"
 }
 
 public enum AnalyticsEventName: String {

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -94,6 +94,7 @@ public enum AnalyticsDisplayName : String {
     case CourseUpgradeErrorAction = "Payments: Error Alert Action"
     case DiscoverExternalLinkOpenAlert = "Discovery: External Link Opening Alert"
     case DiscoverExternalLinkOpenAlertAction = "Discovery: External Link Opening Alert Action"
+    case SDNprompt = "Payments: SDN Prompt"
 }
 
 public enum AnalyticsEventName: String {
@@ -176,6 +177,7 @@ public enum AnalyticsEventName: String {
     case CourseUpgradeErrorAction = "edx.bi.app.payments.error_alert_action"
     case DiscoverExternalLinkOpenAlert = "edx.bi.app.discovery.external_link.opening.alert"
     case DiscoverExternalLinkOpenAlertAction = "edx.bi.app.discovery.external_link.opening.alert_action"
+    case SDNprompt = "edx.bi.app.payments.sdn_prompt_action"
 }
 
 public enum AnalyticsScreenName: String {
@@ -236,6 +238,7 @@ public enum AnalyticsEventDataKey: String {
     case Price = "price"
     case UpgradeError = "error"
     case ErrorAction = "error_action"
+    case Action = "action"
 }
 
 extension OEXAnalytics {

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -94,7 +94,7 @@ public enum AnalyticsDisplayName : String {
     case CourseUpgradeErrorAction = "Payments: Error Alert Action"
     case DiscoverExternalLinkOpenAlert = "Discovery: External Link Opening Alert"
     case DiscoverExternalLinkOpenAlertAction = "Discovery: External Link Opening Alert Action"
-    case SDNprompt = "Payments: SDN Prompt Action"
+    case SDNpromptAction = "Payments: SDN Prompt Action"
 }
 
 public enum AnalyticsEventName: String {

--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -153,6 +153,7 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
     [arguments setSafeObject:@"password" forKey:@"grant_type"];
     [arguments setSafeObject:userName forKey:@"username"];
     [arguments setSafeObject:password forKey:@"password"];
+    [arguments setSafeObject:@"jwt" forKey:@"token_type"];
     return [arguments oex_stringByUsingFormEncoding];
 }
 

--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -153,7 +153,6 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
     [arguments setSafeObject:@"password" forKey:@"grant_type"];
     [arguments setSafeObject:userName forKey:@"username"];
     [arguments setSafeObject:password forKey:@"password"];
-    [arguments setSafeObject:@"jwt" forKey:@"token_type"];
     return [arguments oex_stringByUsingFormEncoding];
 }
 

--- a/Source/PaymentManager.swift
+++ b/Source/PaymentManager.swift
@@ -28,7 +28,8 @@ enum PurchaseError: String {
     case verifyReceiptError // verify receipt API returns error
     case generalError // general error
     case alreadyPurchased // Course is already purchased on the same device
-
+    case sdnError // If user does not opt-in SDN checklist
+    
     var errorString: String {
         switch self {
         case .basketError:

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -218,6 +218,9 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
             self?.enableUserInteraction(enable: false)
             
             switch status {
+            case .sdn:
+                self?.courseUpgradeHelper.handleCourseUpgrade(upgradeHadler: upgradeHandler, state: .sdn)
+                break
             case .payment:
                 self?.courseUpgradeHelper.handleCourseUpgrade(upgradeHadler: upgradeHandler, state: .payment)
                 break

--- a/Source/ar.lproj/CourseUpgrade.strings
+++ b/Source/ar.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/de.lproj/CourseUpgrade.strings
+++ b/Source/de.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/en.lproj/CourseUpgrade.strings
+++ b/Source/en.lproj/CourseUpgrade.strings
@@ -54,3 +54,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/es-419.lproj/CourseUpgrade.strings
+++ b/Source/es-419.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/fr.lproj/CourseUpgrade.strings
+++ b/Source/fr.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/he.lproj/CourseUpgrade.strings
+++ b/Source/he.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/ja.lproj/CourseUpgrade.strings
+++ b/Source/ja.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/pt-BR.lproj/CourseUpgrade.strings
+++ b/Source/pt-BR.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/tr.lproj/CourseUpgrade.strings
+++ b/Source/tr.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/vi.lproj/CourseUpgrade.strings
+++ b/Source/vi.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";

--- a/Source/zh-Hans.lproj/CourseUpgrade.strings
+++ b/Source/zh-Hans.lproj/CourseUpgrade.strings
@@ -56,3 +56,7 @@
 "COURSE_UPGRADE.RESTORE.ALERT_MESSAGE"="All purchases are up to date. If you’re not seeing your purchases restored, please try restarting your app to refresh the experience.";
 /*Title of the inprogress indicator in restore purchases flow*/
 "COURSE_UPGRADE.RESTORE.INPROGRESS_TEXT"="Checking purchases...";
+/*Title of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.TITLE"="SDN";
+/*Message of SDN prompt*/
+"COURSE_UPGRADE.SDN.PROMPT.MESSAGE"="SDN Message Body";


### PR DESCRIPTION
### Description

[LEARNER-8994](https://2u-internal.atlassian.net/browse/LEARNER-8994)

**Pre-Purchase**

Add a prompt after the user taps the ‘Upgrade’ button that informs the user of their personal data being used to verify SDN. Prompt copy TBD. 

- If the user opts-in, continue to the normal check-out flow.
- If the user does not opt-in, cancel the checkout and direct the user to the previous screen.

Add Analytics for SDN `accept` or `cancel`

### How to test this PR

- [ ] SDN prompt shows whenever a user clicks on the upgrade CTA.
- [ ] Prompt CTAs Cancel and Accept
- [ ] Tapping Accept will allow the user to continue forward in the purchase flow.
- [ ] Tapping Cancel will take the user back to the Value Prompt.
- [ ] User must accept the SDN prompt to make a purchase.

### Notes
Title and message of SDN prompt is not finalised yet.