### PR TITLE
[chore] refresh token improvements

### DIFF
--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -183,7 +183,7 @@ extension NSError {
 @objc public enum AccessTokenStatus: Int {
     // First three cases are for logged in user
     case valid = 0 // valid token
-    case failedAuthentication // failed authentication
+    case expired // token expired
     case authenticating // authentication in process
     case invalid // user is logged out
 }
@@ -361,7 +361,7 @@ open class NetworkManager : NSObject {
     }
     
     @discardableResult open func taskForRequest<Out>(base: String? = nil, _ networkRequest : NetworkRequest<Out>, handler: @escaping (NetworkResult<Out>) -> Void) -> Removable? {
-        if tokenStatus == .failedAuthentication {
+        if tokenStatus == .expired {
             if case .authenticate(let authenticateRequest) = authenticator?(nil, nil, true) {
                 authenticateRequest(self, { [weak self] success in
                     self?.handleAuthenticationResponse(base: base, networkRequest: networkRequest, handler: handler, success: success, request: nil, response: nil, baseData: nil, error: nil)

--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -182,10 +182,10 @@ extension NSError {
 
 @objc public enum AccessTokenStatus: Int {
     // First three cases are for logged in user
-    case valid = 0 // Valid token
+    case valid = 0 // valid token
     case failedAuthentication // failed authentication
     case authenticating // authentication in process
-    case invalid // User is logged out
+    case invalid // user is logged out
 }
 
 public struct QueuedTask<T> {
@@ -204,7 +204,7 @@ open class NetworkManager : NSObject {
     public static let NETWORK = "NETWORK" // Logger key
     
     public typealias JSONInterceptor = (_ _response : HTTPURLResponse, _ _json : JSON) -> Result<JSON>
-    public typealias Authenticator = (_ _response: HTTPURLResponse?, _ _data: Data?, _ _needsTokenRefresh: Bool?) -> AuthenticationAction
+    public typealias Authenticator = (_ _response: HTTPURLResponse?, _ _data: Data?, _ _needsTokenRefresh: Bool) -> AuthenticationAction
     
     public let baseURL : URL
     
@@ -364,7 +364,7 @@ open class NetworkManager : NSObject {
         if tokenStatus == .failedAuthentication {
             if case .authenticate(let authenticateRequest) = authenticator?(nil, nil, true) {
                 authenticateRequest(self, { [weak self] success in
-                    self?.handleAuthenticateResponse(base: base, networkRequest: networkRequest, handler: handler, success: success, request: nil, response: nil, baseData: nil, error: nil)
+                    self?.handleAuthenticationResponse(base: base, networkRequest: networkRequest, handler: handler, success: success, request: nil, response: nil, baseData: nil, error: nil)
                 })
             }
             return nil
@@ -389,7 +389,7 @@ open class NetworkManager : NSObject {
             let task = Manager.sharedInstance.request(URLRequest)
             
             let serializer = { [weak self] (URLRequest : Foundation.URLRequest, response : HTTPURLResponse?, data : Data?) -> (AnyObject?, NSError?) in
-                switch authenticator?(response, data!, nil) ?? .proceed {
+                switch authenticator?(response, data!, false) ?? .proceed {
                 case .proceed:
                     let result = NetworkManager.deserialize(networkRequest.deserializer, interceptors: interceptors, response: response, data: data, error: NetworkManager.unknownError)
                     return (Box(DeserializationResult.deserializedResult(value : result, original : data)), result.error)
@@ -411,7 +411,7 @@ open class NetworkManager : NSObject {
                     handler(result)
                 case let .some(.reauthenticationRequest(authHandler, originalData)):
                     authHandler(self, { [weak self] success in
-                        self?.handleAuthenticateResponse(base: base, networkRequest: networkRequest, handler: handler, success: success, request: request, response: response, baseData: originalData, error: error)
+                        self?.handleAuthenticationResponse(base: base, networkRequest: networkRequest, handler: handler, success: success, request: request, response: response, baseData: originalData, error: error)
                     })
                 case let .some(.queuedRequest(request, _)):
                     Logger.logInfo(NetworkManager.NETWORK, "\(request.URLString) queued for token refresh")
@@ -504,15 +504,14 @@ open class NetworkManager : NSObject {
         return result ?? networkResult.data.toResult(NetworkManager.unknownError)
     }
     
-    private func handleAuthenticateResponse<Out>(base: String? = nil, networkRequest : NetworkRequest<Out>, handler: @escaping (NetworkResult<Out>) -> Void, success: Bool, request: URLRequest?, response: HTTPURLResponse?, baseData: Data?, error: NSError?) {
+    private func handleAuthenticationResponse<Out>(base: String? = nil, networkRequest : NetworkRequest<Out>, handler: @escaping (NetworkResult<Out>) -> Void, success: Bool, request: URLRequest?, response: HTTPURLResponse?, baseData: Data?, error: NSError?) {
         if success {
             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting original request")
             performTaskForRequest(base: base, networkRequest, handler: handler)
         } else {
             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful")
-            handler(NetworkResult<Out>(request: request, response: response, data: nil, baseData: baseData, error: error))
+            handler(NetworkResult(request: request, response: response, data: nil, baseData: baseData, error: error))
         }
     }
-    
 }
 

--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -364,7 +364,8 @@ open class NetworkManager : NSObject {
         if tokenStatus == .expired {
             if case .authenticate(let authenticateRequest) = authenticator?(nil, nil, true) {
                 authenticateRequest(self, { [weak self] success in
-                    self?.handleAuthenticationResponse(base: base, networkRequest: networkRequest, handler: handler, success: success, request: nil, response: nil, baseData: nil, error: nil)
+                    let request = self?.URLRequestWithRequest(base: base, networkRequest).value
+                    self?.handleAuthenticationResponse(base: base, networkRequest: networkRequest, handler: handler, success: success, request: request, response: nil, baseData: nil, error: nil)
                 })
             }
             return nil

--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -177,9 +177,9 @@ extension NSError {
 }
 
 public enum AccessTokenStatus {
-    case valid,
-    invalid,
-    refershing
+    case valid
+    case invalid
+    case refershing
 }
 
 public struct QueuedTask<T> {

--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -37,16 +37,23 @@ public enum AuthenticationAction {
     case authenticate(AuthenticateRequestCreator)
     case queue
     
-    public var isProceed : Bool {
+    public var isProceed: Bool {
         switch self {
         case .proceed: return true
         default: return false
         }
     }
     
-    public var isAuthenticate : Bool {
+    public var isAuthenticate: Bool {
         switch self {
         case .authenticate(_): return true
+        default: return false
+        }
+    }
+    
+    public var isQueued: Bool {
+        switch self {
+        case .queue: return true
         default: return false
         }
     }

--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -27,6 +27,7 @@ public enum RequestBody {
 private enum DeserializationResult<Out> {
     case deserializedResult(value : Result<Out>, original : Data?)
     case reauthenticationRequest(AuthenticateRequestCreator, original: Data?)
+    case waitingRequest(URLRequest: URLRequest, original: Data?)
 }
 
 public typealias AuthenticateRequestCreator = (_ _networkManager: NetworkManager, _ _completion: @escaping (_ _success : Bool) -> Void) -> Void
@@ -34,18 +35,19 @@ public typealias AuthenticateRequestCreator = (_ _networkManager: NetworkManager
 public enum AuthenticationAction {
     case proceed
     case authenticate(AuthenticateRequestCreator)
+    case wait
     
     public var isProceed : Bool {
         switch self {
         case .proceed: return true
-        case .authenticate(_): return false
+        default: return false
         }
     }
     
     public var isAuthenticate : Bool {
         switch self {
-        case .proceed: return false
         case .authenticate(_): return true
+        default: return false
         }
     }
 }
@@ -167,6 +169,18 @@ extension NSError {
     }
 }
 
+public enum AccessTokenStatus {
+    case valid,
+    invalid,
+    refershing
+}
+
+public struct WaitingTask<T> {
+    public let base: String?
+    public let networkRequest: NetworkRequest<T>
+    public let handler: (NetworkResult<T>) -> Void
+}
+
 open class NetworkManager : NSObject {
     fileprivate static let errorDomain = "com.edx.NetworkManager"
     enum Error : Int {
@@ -187,6 +201,10 @@ open class NetworkManager : NSObject {
     fileprivate var jsonInterceptors : [JSONInterceptor] = []
     fileprivate var responseInterceptors: [ResponseInterceptor] = []
     open var authenticator : Authenticator?
+    
+    public static var tokenStatus: AccessTokenStatus = .valid
+    
+    public var waitingTasks = [Any]()
     
     @objc public init(authorizationHeaderProvider: AuthorizationHeaderProvider? = nil, credentialProvider : URLCredentialProvider? = nil, baseURL : URL, cache : ResponseCache) {
         self.authorizationHeaderProvider = authorizationHeaderProvider
@@ -328,7 +346,18 @@ open class NetworkManager : NSObject {
         }
     }
     
-    @discardableResult open func taskForRequest<Out>(base: String? = nil, _ networkRequest : NetworkRequest<Out>, handler: @escaping (NetworkResult<Out>) -> Void) -> Removable {
+    @discardableResult open func taskForRequest<Out>(base: String? = nil, _ networkRequest : NetworkRequest<Out>, handler: @escaping (NetworkResult<Out>) -> Void) -> Removable? {
+        
+        if NetworkManager.tokenStatus != .valid {
+            waitingTasks.append(WaitingTask(base: base, networkRequest: networkRequest, handler: handler))
+            return nil
+        }
+        
+        return performTaskForRequest(base: base, networkRequest, handler: handler)
+    }
+    
+    @discardableResult open func performTaskForRequest<Out>(base: String? = nil, _ networkRequest : NetworkRequest<Out>, handler: @escaping (NetworkResult<Out>) -> Void) -> Removable? {
+        
         let URLRequest = URLRequestWithRequest(base: base, networkRequest)
         
         let authenticator = self.authenticator
@@ -337,13 +366,17 @@ open class NetworkManager : NSObject {
             Logger.logInfo(NetworkManager.NETWORK, "Request is \(URLRequest)")
             let task = Manager.sharedInstance.request(URLRequest)
             
-            let serializer = { (URLRequest : Foundation.URLRequest, response : HTTPURLResponse?, data : Data?) -> (AnyObject?, NSError?) in
+            let serializer = { [weak self] (URLRequest : Foundation.URLRequest, response : HTTPURLResponse?, data : Data?) -> (AnyObject?, NSError?) in
                 switch authenticator?(response, data!) ?? .proceed {
                 case .proceed:
                     let result = NetworkManager.deserialize(networkRequest.deserializer, interceptors: interceptors, response: response, data: data, error: NetworkManager.unknownError)
                     return (Box(DeserializationResult.deserializedResult(value : result, original : data)), result.error)
                 case .authenticate(let authenticateRequest):
                     let result = Box<DeserializationResult<Out>>(DeserializationResult.reauthenticationRequest(authenticateRequest, original: data))
+                    return (result, nil)
+                case .wait:
+                    self?.waitingTasks.append(WaitingTask(base: base, networkRequest: networkRequest, handler: handler))
+                    let result = Box<DeserializationResult<Out>>(DeserializationResult.waitingRequest(URLRequest: URLRequest, original: data))
                     return (result, nil)
                 }
             }
@@ -355,25 +388,25 @@ open class NetworkManager : NSObject {
                     Logger.logInfo(NetworkManager.NETWORK, "Response is \(String(describing: response))")
                     handler(result)
                 case let .some(.reauthenticationRequest(authHandler, originalData)):
-                    authHandler(self, {success in
+                    authHandler(self, { [weak self] success in
                         if success {
                             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting original request")
-                            self.taskForRequest(base: base, networkRequest, handler: handler)
+                            self?.performTaskForRequest(base: base, networkRequest, handler: handler)
                         }
                         else {
                             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful")
                             handler(NetworkResult<Out>(request: request, response: response, data: nil, baseData: originalData, error: error))
                         }
                     })
+                case let .some(.waitingRequest(request, _)):
+                    Logger.logInfo(NetworkManager.NETWORK, "\(request.URLString) will wait for refreshing access token")
                 case .none:
                     assert(false, "Deserialization failed in an unexpected way")
                     handler(NetworkResult<Out>(request:request, response:response, data: nil, baseData: nil, error: error))
                 }
             }
-            if let
-                host = URLRequest.url?.host,
-                let credential = self.credentialProvider?.URLCredentialForHost(host as NSString)
-            {
+            if let host = URLRequest.url?.host,
+                let credential = self.credentialProvider?.URLCredentialForHost(host as NSString) {
                 task.authenticate(usingCredential: credential)
             }
             task.resume()
@@ -437,7 +470,7 @@ open class NetworkManager : NSObject {
             result = combineWithPersistentCacheFetch(result, request: request)
         }
         
-        if autoCancel {
+        if autoCancel, let task = task {
             result = result.autoCancel(task)
         }
         

--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -214,9 +214,7 @@ open class NetworkManager : NSObject {
     fileprivate var jsonInterceptors : [JSONInterceptor] = []
     fileprivate var responseInterceptors: [ResponseInterceptor] = []
     open var authenticator : Authenticator?
-    
     @objc public var tokenStatus: AccessTokenStatus
-    
     public var queuedTasks = [Any]()
     
     @objc public init(authorizationDataProvider: (AuthorizationHeaderProvider & SessionDataProvider)? = nil, credentialProvider : URLCredentialProvider? = nil, baseURL : URL, cache : ResponseCache) {

--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -15,7 +15,7 @@ public struct RegistrationFormAPI {
         return json.dictionaryObject.map { OEXRegistrationDescription(dictionary: $0) }.toResult()
     }
     
-    public static func registrationFormRequest(version: String) -> NetworkRequest<(OEXRegistrationDescription)> {
+    public static func registrationFormRequest(version: String) -> NetworkRequest<OEXRegistrationDescription> {
         let path = NSString.oex_string(withFormat: SIGN_UP_URL, parameters: ["version" : version])
         
         return NetworkRequest(method: .GET,

--- a/Source/Core/Test/Code/NetworkManagerTests.swift
+++ b/Source/Core/Test/Code/NetworkManagerTests.swift
@@ -13,9 +13,13 @@ import XCTest
 import edXCore
 
 class NetworkManagerTests: XCTestCase {
-    class AuthProvider : NSObject, AuthorizationHeaderProvider {
+    class AuthProvider : NSObject, AuthorizationHeaderProvider, SessionDataProvider {
         var authorizationHeaders : [String:String] {
             return ["FakeHeader": "TestValue"]
+        }
+        
+        var isUserLoggedin: Bool {
+            return true
         }
     }
     
@@ -29,7 +33,7 @@ class NetworkManagerTests: XCTestCase {
     }
     
     func testGetConstruction() {
-        let manager = NetworkManager(authorizationHeaderProvider: authProvider, baseURL: baseURL, cache : cache)
+        let manager = NetworkManager(authorizationDataProvider: authProvider, baseURL: baseURL, cache : cache)
         let apiRequest = NetworkRequest(
             method: HTTPMethod.GET,
             path: "/something",
@@ -51,7 +55,7 @@ class NetworkManagerTests: XCTestCase {
     }
     
     func testJSONPostConstruction() {
-        let manager = NetworkManager(authorizationHeaderProvider: authProvider, baseURL: baseURL, cache : cache)
+        let manager = NetworkManager(authorizationDataProvider: authProvider, baseURL: baseURL, cache : cache)
         let sampleJSON = JSON([
             "Some field" : true,
             "Some other field" : ["a", "b"]
@@ -79,7 +83,7 @@ class NetworkManagerTests: XCTestCase {
     }
     
     func testFormEncodingPostConstruction() {
-        let manager = NetworkManager(authorizationHeaderProvider: authProvider, baseURL: baseURL, cache : cache)
+        let manager = NetworkManager(authorizationDataProvider: authProvider, baseURL: baseURL, cache : cache)
         let fields = [
             "Some field" : "true",
             "Some other field" : "some value"
@@ -115,7 +119,7 @@ class NetworkManagerTests: XCTestCase {
     }
     
     func requestEnvironment() -> (MockNetworkManager, NetworkRequest<Data>, URLRequest) {
-        let manager = MockNetworkManager(authorizationHeaderProvider: authProvider, baseURL: URL(string:"http://example.com")!)
+        let manager = MockNetworkManager(authorizationDataProvider: authProvider, baseURL: URL(string:"http://example.com")!)
         let request = NetworkRequest<Data> (
             method: HTTPMethod.GET,
             path: "path",
@@ -232,7 +236,7 @@ class NetworkManagerTests: XCTestCase {
     }
     
     func testAuthenticationActionAuthenticateSuccess() {
-        let manager = NetworkManager(authorizationHeaderProvider: nil, baseURL: baseURL, cache : cache)
+        let manager = NetworkManager(authorizationDataProvider: nil, baseURL: baseURL, cache : cache)
         
         let expectation = self.expectation(description: "Request Completes")
         let request = NetworkRequest<JSON> (
@@ -255,7 +259,7 @@ class NetworkManagerTests: XCTestCase {
         })
         
         
-        manager.authenticator = { (response, data) -> AuthenticationAction in
+        manager.authenticator = { (response, data, _) -> AuthenticationAction in
             if response!.statusCode == 401 {
                 return AuthenticationAction.authenticate({ (networkManager, completion) in
                     OHHTTPStubs.removeStub(stub401Response)
@@ -276,7 +280,7 @@ class NetworkManagerTests: XCTestCase {
     }
     
     func testAuthenticationActionAuthenticateFailure() {
-        let manager = NetworkManager(authorizationHeaderProvider: nil, baseURL: baseURL, cache : cache)
+        let manager = NetworkManager(authorizationDataProvider: nil, baseURL: baseURL, cache : cache)
        
         let expectation = self.expectation(description: "Request Completes")
         let request = NetworkRequest<JSON> (
@@ -291,7 +295,7 @@ class NetworkManagerTests: XCTestCase {
                 return expectedStubResponse
         })
         
-        manager.authenticator = { (response, data) -> AuthenticationAction in
+        manager.authenticator = { (response, data, _) -> AuthenticationAction in
             return AuthenticationAction.authenticate({ (networkManager, completion) in
                 OHHTTPStubs.removeStub(stub401Response)
                 return completion(false)

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -12,7 +12,7 @@ import edXCore
 
 extension NetworkManager {
     
-    @objc public func addRefreshTokenAuthenticator(router:OEXRouter, session:OEXSession, clientId:String) {
+    @objc public func addRefreshTokenAuthenticator(router: OEXRouter, session: OEXSession, clientId: String) {
         let invalidAccessAuthenticator = {[weak router] response, data in
             NetworkManager.invalidAccessAuthenticator(router: router, session: session, clientId:clientId, response: response, data: data)
         }
@@ -24,7 +24,7 @@ extension NetworkManager {
      message for an expired access token. If so, a new network request to
      refresh the access token is made and this new access token is saved.
      */
-    public static func invalidAccessAuthenticator(router: OEXRouter?, session:OEXSession, clientId:String, response: HTTPURLResponse?, data: Data?) -> AuthenticationAction {
+    public static func invalidAccessAuthenticator(router: OEXRouter?, session: OEXSession, clientId: String, response: HTTPURLResponse?, data: Data?) -> AuthenticationAction {
         if let data = data,
             let response = response
         {
@@ -35,32 +35,29 @@ extension NetworkManager {
                 guard let statusCode = OEXHTTPStatusCode(rawValue: response.statusCode),
                     let error = NSError(json: json, code: response.statusCode), statusCode.is4xx else
                 {
-                    return AuthenticationAction.proceed
+                    return .proceed
                 }
                 
                 guard let refreshToken = session.token?.refreshToken else {
                     return logout(router: router)
                 }
                 
-                if error.isAPIError(code: .OAuth2Expired) {
-                    return refreshAccessToken(clientId: clientId, refreshToken: refreshToken, session: session)
-                }
-                
                 // Retry request with the current access_token if the original access_token used in
                 // request does not match the current access_token. This case can occur when
                 // asynchronous calls are made and are attempting to refresh the access_token where
                 // one call succeeds but the other fails.
-                if error.isAPIError(code: .OAuth2Nonexistent) {
-                   return refreshAccessToken(clientId: clientId, refreshToken: refreshToken, session: session)
+                
+                if error.isAPIError(code: .OAuth2Expired) || error.isAPIError(code: .OAuth2Nonexistent) {
+                    
+                    if NetworkManager.tokenStatus == .valid {
+                        NetworkManager.tokenStatus = .invalid
+                        return refreshAccessToken(clientId: clientId, refreshToken: refreshToken, session: session)
+                    } else {
+                        return .wait
+                    }
                 }
-                if error.isAPIError(code: .OAuth2InvalidGrant) {
-                    //TODO: Handle invalid_grant gracefully,
-                    //Most of the times it's happening because of hitting /oauth2/access_token/ multiple times with refresh_token
-                    //Only send one request for /oauth2/access_token/
-                    Logger.logError("Network Authenticator", "invalid_grant: " + response.debugDescription)
-                }
-
-                if error.isAPIError(code: .OAuth2DisabledUser) {
+                
+                if error.isAPIError(code: .OAuth2InvalidGrant) || error.isAPIError(code: .OAuth2DisabledUser) {
                     return logout(router: router)
                 }
             }
@@ -71,7 +68,7 @@ extension NetworkManager {
         }
         
         Logger.logError("Network Authenticator", "Request failed: " + response.debugDescription)
-        return AuthenticationAction.proceed
+        return .proceed
     }
 }
 
@@ -85,19 +82,42 @@ private func logout(router:OEXRouter?) -> AuthenticationAction {
 /** Creates a networkRequest to refresh the access_token. If successful, the
  new access token is saved and a successful AuthenticationAction is returned.
  */
-private func refreshAccessToken(clientId:String, refreshToken:String, session: OEXSession) -> AuthenticationAction {
+private func refreshAccessToken(clientId: String, refreshToken: String, session: OEXSession) -> AuthenticationAction {
     return AuthenticationAction.authenticate( { (networkManager,  completion) in
+        
         let networkRequest = LoginAPI.requestTokenWithRefreshToken(
             refreshToken: refreshToken,
             clientId: clientId,
             grantType: "refresh_token"
         )
-        networkManager.taskForRequest(networkRequest) {result in
-            guard let currentUser = session.currentUser, let newAccessToken = result.data else {
-                return completion(false)
+        
+        NetworkManager.tokenStatus = .refershing
+        
+        networkManager.performTaskForRequest(networkRequest) { [weak networkManager] result in
+            
+            // As we have received the result. Now reset token status to valid.
+            NetworkManager.tokenStatus = .valid
+            
+            let success: Bool
+            if let currentUser = session.currentUser {
+                if let newAccessToken = result.data {
+                    session.save(newAccessToken, userDetails: currentUser)
+                    success = true
+                } else {
+                    success = false
+                }
+            } else {
+                
+                // As application has no session.currentUser, it indicates that user is logged out.
+                // So, we must remove waitingTasks if any.
+                networkManager?.removeAllWaitingTasks()
+                success = false
             }
-            session.save(newAccessToken, userDetails: currentUser)
-            return completion(true)
+            
+            // Perform waiting tasks if previously cached.
+            networkManager?.performWaitingTasksIfAny(withReauthenticationResult: success, request: result.request, response: result.response, originalData: result.baseData, error: result.error)
+            
+            return completion(success)
         }
     })
 }

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -112,7 +112,7 @@ private func refreshAccessToken(clientId: String, refreshToken: String, session:
             networkManager?.tokenStatus = .valid
             
             // Perform queued tasks if previously cached.
-            networkManager?.performQueuedTasksIfAny(withReauthenticationResult: success, request: result.request, response: result.response, originalData: result.baseData, error: result.error)
+            networkManager?.performQueuedTasksIfAny(success: success, request: result.request, response: result.response, originalData: result.baseData, error: result.error)
             
             return completion(success)
         }

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -104,7 +104,7 @@ private func refreshAccessToken(router: OEXRouter?, clientId: String, refreshTok
                 }
                 
                 // We need to call this method to allow tasks to callback thier handlers with success or error
-                networkManager?.performQueuedTasksIfAny(success: success, request: result.request, response: result.response, baseData: result.baseData, error: result.error)
+                networkManager?.performQueuedTasksIfAny(success: success)
             } else {
                 // Remove all queued tasks if user details are not available in session
                 networkManager?.removeAllQueuedTasks()

--- a/Source/NetworkManager+QueuedTask.swift
+++ b/Source/NetworkManager+QueuedTask.swift
@@ -12,110 +12,110 @@ import edXCore
 
 extension NetworkManager {
     
-    func performQueuedTasksIfAny(withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
+    func performQueuedTasksIfAny(success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
         if queuedTasks.isEmpty { return }
         
         for queuedTask in queuedTasks {
             
             switch queuedTask {
             case let task as QueuedTask<()>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<UserPreference>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<[UserCourseEnrollment]>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<Paginated<[OEXCourse]>>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<Paginated<[DiscussionThread]>>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<Paginated<[DiscussionComment]>>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<Paginated<[Int]>>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<Paginated<[BadgeAssertion]>>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<OrderBasket>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<CheckoutBasket>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<OrderVerify>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<[OEXAnnouncement]>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<[UserCourseEnrollment]>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<[String]>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<[DiscussionTopic]>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<OEXCourse>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<UserCourseEnrollment>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<CourseOutline>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<ResumeCourseItem>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<String>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<CourseDateModel>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<CourseDateBannerModel>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<CourseCelebrationModel>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<DiscussionThread>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<DiscussionComment>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<DiscussionInfo>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<UserProfile>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<OEXRegistrationDescription>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<RegistrationFormValidation>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<OEXAccessToken>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<JSON>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<Data>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             case let task as QueuedTask<RemoteImage>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
                 
             default:
                 assert(false, "Unable to handle task: \(queuedTask)")
@@ -129,7 +129,7 @@ extension NetworkManager {
         queuedTasks.removeAll()
     }
     
-    private func performTask<T>(task: QueuedTask<T>, withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
+    private func performTask<T>(task: QueuedTask<T>, success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
         if success {
             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting request in queue")
             performTaskForRequest(base: task.base, task.networkRequest, handler: task.handler)

--- a/Source/NetworkManager+QueuedTask.swift
+++ b/Source/NetworkManager+QueuedTask.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkManager+WaitingTask.swift
+//  NetworkManager+QueuedTask.swift
 //  edX
 //
 //  Created by AsifBilal on 7/29/22.
@@ -12,134 +12,130 @@ import edXCore
 
 extension NetworkManager {
     
-    func performWaitingTasksIfAny(withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
-        if waitingTasks.isEmpty { return}
+    func performQueuedTasksIfAny(withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
+        if queuedTasks.isEmpty { return }
         
-        for waitingTask in waitingTasks {
+        for queuedTask in queuedTasks {
             
-            switch waitingTask {
-            case let task as WaitingTask<()>:
-                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
-            case let task as WaitingTask<UserPreference>:
+            switch queuedTask {
+            case let task as QueuedTask<()>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<[UserCourseEnrollment]>:
+            case let task as QueuedTask<UserPreference>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<Paginated<[OEXCourse]>>:
+            case let task as QueuedTask<[UserCourseEnrollment]>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<Paginated<[DiscussionThread]>>:
+            case let task as QueuedTask<Paginated<[OEXCourse]>>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<Paginated<[DiscussionComment]>>:
+            case let task as QueuedTask<Paginated<[DiscussionThread]>>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<Paginated<[Int]>>:
+            case let task as QueuedTask<Paginated<[DiscussionComment]>>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<Paginated<[BadgeAssertion]>>:
+            case let task as QueuedTask<Paginated<[Int]>>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<OrderBasket>:
+            case let task as QueuedTask<Paginated<[BadgeAssertion]>>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<CheckoutBasket>:
+            case let task as QueuedTask<OrderBasket>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<OrderVerify>:
+            case let task as QueuedTask<CheckoutBasket>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<[OEXAnnouncement]>:
+            case let task as QueuedTask<OrderVerify>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<[UserCourseEnrollment]>:
+            case let task as QueuedTask<[OEXAnnouncement]>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<[String]>:
+            case let task as QueuedTask<[UserCourseEnrollment]>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<[DiscussionTopic]>:
+            case let task as QueuedTask<[String]>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<OEXCourse>:
+            case let task as QueuedTask<[DiscussionTopic]>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<UserCourseEnrollment>:
+            case let task as QueuedTask<OEXCourse>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<CourseOutline>:
+            case let task as QueuedTask<UserCourseEnrollment>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<ResumeCourseItem>:
+            case let task as QueuedTask<CourseOutline>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<String>:
+            case let task as QueuedTask<ResumeCourseItem>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<CourseDateModel>:
+            case let task as QueuedTask<String>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<CourseDateBannerModel>:
+            case let task as QueuedTask<CourseDateModel>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<CourseCelebrationModel>:
+            case let task as QueuedTask<CourseDateBannerModel>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<DiscussionThread>:
+            case let task as QueuedTask<CourseCelebrationModel>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<DiscussionComment>:
+            case let task as QueuedTask<DiscussionThread>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<DiscussionInfo>:
+            case let task as QueuedTask<DiscussionComment>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<UserProfile>:
+            case let task as QueuedTask<DiscussionInfo>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<OEXRegistrationDescription>:
+            case let task as QueuedTask<UserProfile>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<RegistrationFormValidation>:
+            case let task as QueuedTask<OEXRegistrationDescription>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<OEXAccessToken>:
+            case let task as QueuedTask<RegistrationFormValidation>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<JSON>:
+            case let task as QueuedTask<OEXAccessToken>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<Data>:
+            case let task as QueuedTask<JSON>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
-            case let task as WaitingTask<RemoteImage>:
+            case let task as QueuedTask<Data>:
                 performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
+            case let task as QueuedTask<RemoteImage>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
                 
             default:
-                assert(false, "Did not handle task with this type: \(waitingTask)")
-                
+                assert(false, "Unable to handle task: \(queuedTask)")
             }
         }
-        
         // As we have enqueued all tasks, now remove the tasks.
-        removeAllWaitingTasks()
+        removeAllQueuedTasks()
     }
     
-    func removeAllWaitingTasks() {
-        waitingTasks.removeAll()
+    func removeAllQueuedTasks() {
+        queuedTasks.removeAll()
     }
     
-    private func performTask<T>(task: WaitingTask<T>, withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
-        
+    private func performTask<T>(task: QueuedTask<T>, withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
         if success {
-            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting request in waiting")
+            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting request in queue")
             performTaskForRequest(base: task.base, task.networkRequest, handler: task.handler)
         } else {
-            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful so skip attempting for waiting request: \(task.networkRequest.path)")
+            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful so skip attempting for queued request: \(task.networkRequest.path)")
             task.handler(NetworkResult<T>(request: request, response: response, data: nil, baseData: originalData, error: error))
         }
-        
     }
 }

--- a/Source/NetworkManager+QueuedTask.swift
+++ b/Source/NetworkManager+QueuedTask.swift
@@ -12,109 +12,110 @@ import edXCore
 
 extension NetworkManager {
     
-    func performQueuedTasksIfAny(success: Bool, request: URLRequest?, response: HTTPURLResponse?, baseData: Data?, error: NSError?) {
+    func 
+    performQueuedTasksIfAny(success: Bool) {
         if queuedTasks.isEmpty { return }
         
         for queuedTask in queuedTasks {
             switch queuedTask {
             case let task as QueuedTask<()>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<UserPreference>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<[UserCourseEnrollment]>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<Paginated<[OEXCourse]>>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<Paginated<[DiscussionThread]>>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<Paginated<[DiscussionComment]>>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<Paginated<[Int]>>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<Paginated<[BadgeAssertion]>>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<OrderBasket>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<CheckoutBasket>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<OrderVerify>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<[OEXAnnouncement]>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<[UserCourseEnrollment]>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<[String]>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<[DiscussionTopic]>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<OEXCourse>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<UserCourseEnrollment>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<CourseOutline>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<ResumeCourseItem>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<String>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<CourseDateModel>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<CourseDateBannerModel>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<CourseCelebrationModel>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<DiscussionThread>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<DiscussionComment>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<DiscussionInfo>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<UserProfile>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<OEXRegistrationDescription>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<RegistrationFormValidation>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<OEXAccessToken>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<JSON>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<Data>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             case let task as QueuedTask<RemoteImage>:
-                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
+                performTask(task: task, success: success)
                 
             default:
                 Logger.logInfo(NetworkManager.NETWORK, "Unable to handle task: \(queuedTask)")
@@ -128,13 +129,14 @@ extension NetworkManager {
         queuedTasks.removeAll()
     }
     
-    private func performTask<T>(task: QueuedTask<T>, success: Bool, request: URLRequest?, response: HTTPURLResponse?, baseData: Data?, error: NSError?) {
+    private func performTask<T>(task: QueuedTask<T>, success: Bool) {
         if success {
             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting request in queue")
             performTaskForRequest(base: task.base, task.networkRequest, handler: task.handler)
         } else {
-            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful so skip attempting for queued request: \(task.networkRequest.path)")
-            task.handler(NetworkResult(request: request, response: response, data: nil, baseData: baseData, error: error))
+            let request = URLRequestWithRequest(base: task.base, task.networkRequest).value
+            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful so skip attempting for queued request: \(String(describing: request?.URLString))")
+            task.handler(NetworkResult(request: request, response: nil, data: nil, baseData: nil, error: nil))
         }
     }
 }

--- a/Source/NetworkManager+QueuedTask.swift
+++ b/Source/NetworkManager+QueuedTask.swift
@@ -16,7 +16,6 @@ extension NetworkManager {
         if queuedTasks.isEmpty { return }
         
         for queuedTask in queuedTasks {
-            
             switch queuedTask {
             case let task as QueuedTask<()>:
                 performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)

--- a/Source/NetworkManager+QueuedTask.swift
+++ b/Source/NetworkManager+QueuedTask.swift
@@ -12,113 +12,113 @@ import edXCore
 
 extension NetworkManager {
     
-    func performQueuedTasksIfAny(success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
+    func performQueuedTasksIfAny(success: Bool, request: URLRequest?, response: HTTPURLResponse?, baseData: Data?, error: NSError?) {
         if queuedTasks.isEmpty { return }
         
         for queuedTask in queuedTasks {
             
             switch queuedTask {
             case let task as QueuedTask<()>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<UserPreference>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<[UserCourseEnrollment]>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<Paginated<[OEXCourse]>>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<Paginated<[DiscussionThread]>>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<Paginated<[DiscussionComment]>>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<Paginated<[Int]>>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<Paginated<[BadgeAssertion]>>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<OrderBasket>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<CheckoutBasket>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<OrderVerify>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<[OEXAnnouncement]>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<[UserCourseEnrollment]>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<[String]>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<[DiscussionTopic]>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<OEXCourse>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<UserCourseEnrollment>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<CourseOutline>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<ResumeCourseItem>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<String>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<CourseDateModel>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<CourseDateBannerModel>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<CourseCelebrationModel>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<DiscussionThread>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<DiscussionComment>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<DiscussionInfo>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<UserProfile>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<OEXRegistrationDescription>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<RegistrationFormValidation>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<OEXAccessToken>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<JSON>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<Data>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             case let task as QueuedTask<RemoteImage>:
-                performTask(task: task, success: success, request: request, response: response, originalData: originalData, error: error)
+                performTask(task: task, success: success, request: request, response: response, baseData: baseData, error: error)
                 
             default:
-                assert(false, "Unable to handle task: \(queuedTask)")
+                Logger.logInfo(NetworkManager.NETWORK, "Unable to handle task: \(queuedTask)")
             }
         }
         // As we have enqueued all tasks, now remove the tasks.
@@ -129,13 +129,13 @@ extension NetworkManager {
         queuedTasks.removeAll()
     }
     
-    private func performTask<T>(task: QueuedTask<T>, success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
+    private func performTask<T>(task: QueuedTask<T>, success: Bool, request: URLRequest?, response: HTTPURLResponse?, baseData: Data?, error: NSError?) {
         if success {
             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting request in queue")
             performTaskForRequest(base: task.base, task.networkRequest, handler: task.handler)
         } else {
             Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful so skip attempting for queued request: \(task.networkRequest.path)")
-            task.handler(NetworkResult<T>(request: request, response: response, data: nil, baseData: originalData, error: error))
+            task.handler(NetworkResult(request: request, response: response, data: nil, baseData: baseData, error: error))
         }
     }
 }

--- a/Source/NetworkManager+WaitingTask.swift
+++ b/Source/NetworkManager+WaitingTask.swift
@@ -1,0 +1,145 @@
+//
+//  NetworkManager+WaitingTask.swift
+//  edX
+//
+//  Created by AsifBilal on 7/29/22.
+//  Copyright © 2022 edX. All rights reserved.
+//
+
+import Foundation
+
+import edXCore
+
+extension NetworkManager {
+    
+    func performWaitingTasksIfAny(withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
+        if waitingTasks.isEmpty { return}
+        
+        for waitingTask in waitingTasks {
+            
+            switch waitingTask {
+            case let task as WaitingTask<()>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+            case let task as WaitingTask<UserPreference>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<[UserCourseEnrollment]>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<Paginated<[OEXCourse]>>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<Paginated<[DiscussionThread]>>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<Paginated<[DiscussionComment]>>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<Paginated<[Int]>>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<Paginated<[BadgeAssertion]>>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<OrderBasket>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<CheckoutBasket>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<OrderVerify>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<[OEXAnnouncement]>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<[UserCourseEnrollment]>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<[String]>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<[DiscussionTopic]>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<OEXCourse>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<UserCourseEnrollment>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<CourseOutline>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<ResumeCourseItem>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<String>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<CourseDateModel>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<CourseDateBannerModel>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<CourseCelebrationModel>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<DiscussionThread>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<DiscussionComment>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<DiscussionInfo>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<UserProfile>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<OEXRegistrationDescription>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<RegistrationFormValidation>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<OEXAccessToken>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<JSON>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<Data>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+            case let task as WaitingTask<RemoteImage>:
+                performTask(task: task, withReauthenticationResult: success, request: request, response: response, originalData: originalData, error: error)
+                
+                
+            default:
+                assert(false, "Did not handle task with this type: \(waitingTask)")
+                
+            }
+        }
+        
+        // As we have enqueued all tasks, now remove the tasks.
+        removeAllWaitingTasks()
+    }
+    
+    func removeAllWaitingTasks() {
+        waitingTasks.removeAll()
+    }
+    
+    private func performTask<T>(task: WaitingTask<T>, withReauthenticationResult success: Bool, request: URLRequest?, response: HTTPURLResponse?, originalData: Data?, error: NSError?) {
+        
+        if success {
+            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting request in waiting")
+            performTaskForRequest(base: task.base, task.networkRequest, handler: task.handler)
+        } else {
+            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful so skip attempting for waiting request: \(task.networkRequest.path)")
+            task.handler(NetworkResult<T>(request: request, response: response, data: nil, baseData: originalData, error: error))
+        }
+        
+    }
+}

--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -209,6 +209,7 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
             OEXUserDetails* userDetails = [[OEXUserDetails alloc] initWithUserDictionary:dictionary];
             if(token != nil && userDetails != nil) {
                 [[OEXSession sharedSession] saveAccessToken:token userDetails:userDetails];
+                [[OEXRouter sharedRouter].environment.networkManager setTokenStatus:AccessTokenStatusValid];
             }
             else {
                 // On the off chance that something messed up and we have nil

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -123,7 +123,7 @@
         self.networkManagerBuilder = ^(OEXEnvironment* env) {
             PersistentResponseCache* cache = [[PersistentResponseCache alloc] initWithProvider: [[SessionUsernameProvider alloc] initWithSession:env.session]];
             NetworkManager* manager = [[NetworkManager alloc]
-                                       initWithAuthorizationHeaderProvider:env.session
+                                       initWithAuthorizationDataProvider:env.session
                                        credentialProvider:env.config
                                        baseURL:env.config.apiHostURL
                                        cache: cache];

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -569,7 +569,7 @@ extension OEXRouter {
             let networkRequest = LogoutApi.invalidateToken(refreshToken: refreshToken, clientID: clientID)
             // As this is logout request, so must not add it to queuedTasks while refreshing. This must be called directly.
             // So in order to avoid from adding in queuedTasks, we directly call the 'performTaskForRequest' function.
-            environment.networkManager.performTaskForRequest(networkRequest) { result in}
+            environment.networkManager.performTaskForRequest(networkRequest) { result in }
         }
     }
 

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -567,7 +567,9 @@ extension OEXRouter {
     func invalidateToken() {
         if let refreshToken = environment.session.token?.refreshToken, let clientID = environment.config.oauthClientID() {
             let networkRequest = LogoutApi.invalidateToken(refreshToken: refreshToken, clientID: clientID)
-            environment.networkManager.taskForRequest(networkRequest) { result in }
+            // As this is logout request, so must not add it to waitingTasks while refreshing. This must be called directly.
+            // So in order to avoid from adding in waitingTasks, we directly call the 'performTaskForRequest' function.
+            environment.networkManager.performTaskForRequest(networkRequest) { result in}
         }
     }
 

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -558,18 +558,17 @@ extension OEXRouter {
     }
     
     @objc public func logout() {
-        invalidateToken()
+        environment.networkManager.tokenStatus = .invalid
         environment.session.closeAndClear()
         environment.session.removeAllWebData()
+        invalidateToken()
         showLoggedOutScreen()
     }
     
     func invalidateToken() {
         if let refreshToken = environment.session.token?.refreshToken, let clientID = environment.config.oauthClientID() {
             let networkRequest = LogoutApi.invalidateToken(refreshToken: refreshToken, clientID: clientID)
-            // As this is logout request, so must not add it to queuedTasks while refreshing. This must be called directly.
-            // So in order to avoid from adding in queuedTasks, we directly call the 'performTaskForRequest' function.
-            environment.networkManager.performTaskForRequest(networkRequest) { result in }
+            environment.networkManager.taskForRequest(networkRequest) { result in }
         }
     }
 

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -567,8 +567,8 @@ extension OEXRouter {
     func invalidateToken() {
         if let refreshToken = environment.session.token?.refreshToken, let clientID = environment.config.oauthClientID() {
             let networkRequest = LogoutApi.invalidateToken(refreshToken: refreshToken, clientID: clientID)
-            // As this is logout request, so must not add it to waitingTasks while refreshing. This must be called directly.
-            // So in order to avoid from adding in waitingTasks, we directly call the 'performTaskForRequest' function.
+            // As this is logout request, so must not add it to queuedTasks while refreshing. This must be called directly.
+            // So in order to avoid from adding in queuedTasks, we directly call the 'performTaskForRequest' function.
             environment.networkManager.performTaskForRequest(networkRequest) { result in}
         }
     }

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -559,9 +559,9 @@ extension OEXRouter {
     
     @objc public func logout() {
         environment.networkManager.tokenStatus = .invalid
+        invalidateToken()
         environment.session.closeAndClear()
         environment.session.removeAllWebData()
-        invalidateToken()
         showLoggedOutScreen()
     }
     

--- a/Source/OEXSession+SessionData.swift
+++ b/Source/OEXSession+SessionData.swift
@@ -1,0 +1,15 @@
+//
+//  OEXSession+SessionData.swift
+//  edX
+//
+//  Created by AsifBilal on 8/24/22.
+//  Copyright © 2022 edX. All rights reserved.
+//
+
+import Foundation
+
+extension OEXSession: SessionDataProvider {
+    public var isUserLoggedin: Bool {
+        return doesUserDetailsExist()
+    }
+}

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -38,6 +38,7 @@ extern NSString* const OEXSessionEndedNotification;
 /// When registration is sucssessful, this token is removed.
 @property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
 
+- (BOOL)doesUserDetailsExist;
 - (void)loadTokenFromStore;
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails;
 - (void)closeAndClearSession;

--- a/Source/OEXSession.m
+++ b/Source/OEXSession.m
@@ -72,6 +72,10 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
     self.thirdPartyAuthAccessToken = nil;
 }
 
+- (BOOL)doesUserDetailsExist {
+    return self.credentialStore.storedUserDetails != nil;
+}
+
 - (void)loadTokenFromStore {
     OEXAccessToken* tokenData = self.credentialStore.storedAccessToken;
     OEXUserDetails* userDetails = self.credentialStore.storedUserDetails;

--- a/Source/RemoteImage.swift
+++ b/Source/RemoteImage.swift
@@ -14,7 +14,7 @@ protocol RemoteImage {
     var image: UIImage? { get }
     
     /** Callback should be on main thread */
-    func fetchImage(completion: @escaping (_ remoteImage: NetworkResult<RemoteImage>) -> ()) -> Removable
+    func fetchImage(completion: @escaping (_ remoteImage: NetworkResult<RemoteImage>) -> ()) -> Removable?
 }
 
 
@@ -81,7 +81,7 @@ class RemoteImageImpl: RemoteImage {
     }
     
     /** Callback should be on main thread */
-    @discardableResult func fetchImage(completion: @escaping (NetworkResult<RemoteImage>) -> ()) -> Removable {
+    @discardableResult func fetchImage(completion: @escaping (NetworkResult<RemoteImage>) -> ()) -> Removable? {
         // Only authorize requests to the API host
         // This is necessary for two reasons:
         // 1. We don't want to leak credentials by loading random images
@@ -111,7 +111,7 @@ struct RemoteImageJustImage : RemoteImage {
         self.placeholder = image
     }
     
-    func fetchImage(completion: @escaping (NetworkResult<RemoteImage>) -> ()) -> Removable {
+    func fetchImage(completion: @escaping (NetworkResult<RemoteImage>) -> ()) -> Removable? {
         let result = NetworkResult<RemoteImage>(request: nil, response: nil, data: self, baseData: nil, error: nil)
         completion(result)
         return BlockRemovable {}

--- a/Test/CourseOutlineQuerierTests.swift
+++ b/Test/CourseOutlineQuerierTests.swift
@@ -17,7 +17,7 @@ class CourseOutlineQuerierTests: XCTestCase {
     
     func testBlockLoadsFromNetwork() {
         let outline = CourseOutlineTestDataFactory.freshCourseOutline(courseID)
-        let networkManager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: URL(string : "http://www.example.com")!)
+        let networkManager = MockNetworkManager(authorizationDataProvider: nil, baseURL: URL(string : "http://www.example.com")!)
         networkManager.interceptWhenMatching({_ in true}, successResponse: {
             return (nil, outline)
         })
@@ -86,7 +86,7 @@ class CourseOutlineQuerierTests: XCTestCase {
     }
     
     func testReloadsAfterFailure() {
-        let networkManager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: URL(string : "http://www.example.com")!)
+        let networkManager = MockNetworkManager(authorizationDataProvider: nil, baseURL: URL(string : "http://www.example.com")!)
         let querier = CourseOutlineQuerier(courseID: courseID, interface: nil, enrollmentManager: nil, networkManager: networkManager, session : nil, environment: testEnvironment)
         let blockID = CourseOutlineTestDataFactory.knownSection
         

--- a/Test/EndToEnd/Code/TestCredentials.swift
+++ b/Test/EndToEnd/Code/TestCredentials.swift
@@ -35,7 +35,7 @@ private class TestCredentialManager {
     }()
 
     func registerUser(_ credentials: Credentials) {
-        let networkManager = NetworkManager(authorizationHeaderProvider: nil, credentialProvider: nil, baseURL: config.apiHostURL()!, cache: MockResponseCache())
+        let networkManager = NetworkManager(authorizationDataProvider: nil, credentialProvider: nil, baseURL: config.apiHostURL()!, cache: MockResponseCache())
         let body = [
             "email": credentials.email,
             "username": credentials.username,

--- a/Test/MockNetworkManager.swift
+++ b/Test/MockNetworkManager.swift
@@ -36,8 +36,8 @@ class MockNetworkManager: NetworkManager {
     
     let responseCache = MockResponseCache()
     
-    init(authorizationHeaderProvider: AuthorizationHeaderProvider? = nil, baseURL: URL = NSURL(string:"http://example.com")! as URL) {
-        super.init(authorizationHeaderProvider: authorizationHeaderProvider, baseURL: baseURL, cache: responseCache)
+    init(authorizationDataProvider: (AuthorizationHeaderProvider & SessionDataProvider)? = nil, baseURL: URL = NSURL(string:"http://example.com")! as URL) {
+        super.init(authorizationDataProvider: authorizationDataProvider, baseURL: baseURL, cache: responseCache)
     }
     
     @discardableResult func interceptWhenMatching<Out>(_ matcher: @escaping (NetworkRequest<Out>) -> Bool, afterDelay delay : TimeInterval = 0, withResponse response : @escaping (NetworkRequest<Out>) -> NetworkResult<Out>) -> Removable {
@@ -109,7 +109,7 @@ class MockNetworkManager: NetworkManager {
 class MockNetworkManagerTests : XCTestCase {
     
     func testInterception() {
-        let manager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: URL(string : "http://example.com")!)
+        let manager = MockNetworkManager(authorizationDataProvider: nil, baseURL: URL(string : "http://example.com")!)
         manager.interceptWhenMatching({ _ in true}, withResponse: { _ -> NetworkResult<String> in
             NetworkResult(request : nil, response : nil, data : "Success", baseData : nil, error : nil)
         })
@@ -127,7 +127,7 @@ class MockNetworkManagerTests : XCTestCase {
     }
     
     func testNoInterceptorsFails() {
-        let manager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: URL(string : "http://example.com")!)
+        let manager = MockNetworkManager(authorizationDataProvider: nil, baseURL: URL(string : "http://example.com")!)
         
         let expectation = self.expectation(description: "Request sent")
         let request = NetworkRequest(method: HTTPMethod.GET, path: "/test", deserializer: .dataResponse({ _,_  -> Result<String> in

--- a/Test/MockRouter.swift
+++ b/Test/MockRouter.swift
@@ -11,9 +11,10 @@ import Foundation
 
 class MockRouter: OEXRouter {
     var logoutCalled = false
+    var testType: String = ""
 
     override func logout() {
         logoutCalled = true
-        NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: "MockLogOutCalled")))
+        NotificationCenter.default.post(name:  Notification.Name(rawValue: "MockLogOutCalled"), object: testType)
     }
 }

--- a/Test/MockRouter.swift
+++ b/Test/MockRouter.swift
@@ -15,6 +15,6 @@ class MockRouter: OEXRouter {
 
     override func logout() {
         logoutCalled = true
-        NotificationCenter.default.post(name:  Notification.Name(rawValue: "MockLogOutCalled"), object: testType)
+        NotificationCenter.default.post(name: Notification.Name(rawValue: "MockLogOutCalled"), object: testType)
     }
 }

--- a/Test/MockRouter.swift
+++ b/Test/MockRouter.swift
@@ -11,7 +11,7 @@ import Foundation
 
 class MockRouter: OEXRouter {
     var logoutCalled = false
-    var testType: String = ""
+    var testType: String?
 
     override func logout() {
         logoutCalled = true

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -30,7 +30,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testAuthenticatorDoesNothing() {
-        let router = MockRouter()
+        let router = mockRouterBuilder()
         let session = OEXSession()
         let response = simpleResponseBuilder(200)
         let data = "{}".data(using: String.Encoding.utf8)!
@@ -40,7 +40,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testLogoutWithNoRefreshToken() {
-        let router = MockRouter()
+        let router = mockRouterBuilder()
         let session = OEXSession()
         let response = simpleResponseBuilder(401)
         let data = "{\"error_code\":\"token_expired\"}".data(using: String.Encoding.utf8)!
@@ -50,7 +50,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testNonExistentAccessToken() {
-        let router = MockRouter()
+        let router = mockRouterBuilder()
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(400)
         let data = "{\"error\":\"token_nonexistent\"}".data(using: String.Encoding.utf8)!
@@ -59,7 +59,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
 
     func testInvalidGrantAccessToken() {
-        let router = MockRouter()
+        let router = mockRouterBuilder()
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(401)
         let data = "{\"error_code\":\"invalid_grant\"}".data(using: String.Encoding.utf8)!
@@ -69,7 +69,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testLogoutWithNonJSONData() {
-        let router = MockRouter()
+        let router = mockRouterBuilder()
         let session = OEXSession()
         let response = simpleResponseBuilder(200)
         let data = "I AM NOT A JSON".data(using: String.Encoding.utf8)!
@@ -79,7 +79,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testExpiredAccessTokenReturnsAuthenticate() {
-        let router = MockRouter()
+        let router = mockRouterBuilder()
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(401)
         let data = "{\"error_code\":\"token_expired\"}".data(using: String.Encoding.utf8)!
@@ -112,5 +112,10 @@ class NetworkManager_AuthenticationTests : XCTestCase {
             method: HTTPMethod.GET,
             path: "path",
             deserializer: .jsonResponse({(_, json) in .success(json)}))
+    }
+    
+    func mockRouterBuilder() -> MockRouter {
+        MockRouter(environment: TestRouterEnvironment(config: OEXConfig(dictionary:[:]),
+                                                      interface: OEXInterface.shared()))
     }
 }

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -43,7 +43,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     
     func testLogoutWithNoRefreshToken() {
         let router = mockRouterBuilder()
-        router.testType = #function
+        router.testType = "testLogoutWithNoRefreshToken"
         
         let session = OEXSession()
         let response = simpleResponseBuilder(401)
@@ -119,7 +119,6 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func mockRouterBuilder() -> MockRouter {
-        return MockRouter(environment: TestRouterEnvironment(config: OEXConfig(dictionary:[:]),
-                                                      interface: OEXInterface.shared()))
+        return MockRouter(environment: TestRouterEnvironment(config: OEXConfig(dictionary:[:]), interface: OEXInterface.shared()))
     }
 }

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -103,6 +103,17 @@ class NetworkManager_AuthenticationTests : XCTestCase {
         return session
     }
     
+    func testMultipleRequestsWithExpiredAccessToken() {
+        let router = mockRouterBuilder()
+        let session = sessionWithRefreshTokenBuilder()
+        let response = simpleResponseBuilder(401)
+        let data = "{\"error_code\":\"token_expired\"}".data(using: String.Encoding.utf8)!
+        let firstResult = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: false)
+        let secondResult = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: false)
+        XCTAssertTrue(firstResult.isAuthenticate)
+        XCTAssertTrue(secondResult.isQueued)
+    }
+    
     func simpleResponseBuilder(_ statusCode: Int) -> HTTPURLResponse?{
         return HTTPURLResponse(
             url: URL(string: "http://www.example.com")!,

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -18,8 +18,10 @@ class NetworkManager_AuthenticationTests : XCTestCase {
         if waitForLogout {
             let expectation = self.expectation(description: "wait for mock LogOut")
 
-            let removeable = NotificationCenter.default.oex_addObserver(observer: self, name: "MockLogOutCalled") { (_, _, _) in
-                expectation.fulfill()
+            let removeable = NotificationCenter.default.oex_addObserver(observer: self, name: "MockLogOutCalled") { [weak router] (notification, _, _) in
+                if router?.testType == notification.object as? String {
+                    expectation.fulfill()
+                }
             }
 
             waitForExpectations()
@@ -41,6 +43,8 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     
     func testLogoutWithNoRefreshToken() {
         let router = mockRouterBuilder()
+        router.testType = #function
+        
         let session = OEXSession()
         let response = simpleResponseBuilder(401)
         let data = "{\"error_code\":\"token_expired\"}".data(using: String.Encoding.utf8)!
@@ -115,7 +119,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func mockRouterBuilder() -> MockRouter {
-        MockRouter(environment: TestRouterEnvironment(config: OEXConfig(dictionary:[:]),
+        return MockRouter(environment: TestRouterEnvironment(config: OEXConfig(dictionary:[:]),
                                                       interface: OEXInterface.shared()))
     }
 }

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -13,7 +13,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     func authenticatorResponseForRequest(
         _ response: HTTPURLResponse, data: Data, session: OEXSession, router: MockRouter, waitForLogout: Bool) -> AuthenticationAction {
         let clientId = "dummy client_id"
-        let result = NetworkManager.invalidAccessAuthenticator(router: router, session: session, clientId: clientId, response: response, data: data)
+            let result = NetworkManager.invalidAccessAuthenticator(router: router, session: session, clientId: clientId, response: response, data: data)
         
         if waitForLogout {
             let expectation = self.expectation(description: "wait for mock LogOut")
@@ -53,7 +53,8 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testNonExistentAccessToken() {
-        let environment = TestRouterEnvironment()
+        let user = OEXUserDetails.freshUser()
+        let environment = TestRouterEnvironment(user: user)
         let router = MockRouter(environment: environment)
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(400)
@@ -83,7 +84,8 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testExpiredAccessTokenReturnsAuthenticate() {
-        let environment = TestRouterEnvironment()
+        let user = OEXUserDetails.freshUser()
+        let environment = TestRouterEnvironment(user: user)
         let router = MockRouter(environment: environment)
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(401)
@@ -93,7 +95,8 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testMultipleRequestsWithExpiredAccessToken() {
-        let environment = TestRouterEnvironment()
+        let user = OEXUserDetails.freshUser()
+        let environment = TestRouterEnvironment(user: user)
         let router = MockRouter(environment: environment)
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(401)

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -53,14 +53,13 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     }
     
     func testNonExistentAccessToken() {
-        let user = OEXUserDetails.freshUser()
-        let environment = TestRouterEnvironment(user: user)
-        let router = MockRouter(environment: environment)
+        let router = MockRouter()
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(400)
         let data = "{\"error\":\"token_nonexistent\"}".data(using: String.Encoding.utf8)!
         let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: false)
-        XCTAssertTrue(result.isAuthenticate)
+        XCTAssertTrue(result.isProceed)
+        XCTAssertFalse(router.logoutCalled)
     }
 
     func testInvalidGrantAccessToken() {

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -13,7 +13,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     func authenticatorResponseForRequest(
         _ response: HTTPURLResponse, data: Data, session: OEXSession, router: MockRouter, waitForLogout: Bool) -> AuthenticationAction {
         let clientId = "dummy client_id"
-            let result = NetworkManager.invalidAccessAuthenticator(router: router, session: session, clientId: clientId, response: response, data: data)
+        let result = NetworkManager.invalidAccessAuthenticator(router: router, session: session, clientId: clientId, response: response, data: data, needsTokenRefresh: false)
         
         if waitForLogout {
             let expectation = self.expectation(description: "wait for mock LogOut")

--- a/Test/NetworkManager+InterceptionTests.swift
+++ b/Test/NetworkManager+InterceptionTests.swift
@@ -11,7 +11,7 @@ class NetworkManager_InterceptionTests : XCTestCase {
 
     func checkJSONInterceptionWithStubResponse(_ router: OEXRouter, stubResponse : OHHTTPStubsResponse, verifier : @escaping (Result<JSON>) -> Void) {
 
-        let manager = NetworkManager(authorizationHeaderProvider: nil, baseURL: URL(string:"http://example.com")!, cache : MockResponseCache())
+        let manager = NetworkManager(authorizationDataProvider: nil, baseURL: URL(string:"http://example.com")!, cache : MockResponseCache())
         manager.addStandardInterceptors()
         let request = NetworkRequest<JSON> (
             method: HTTPMethod.GET,
@@ -56,7 +56,7 @@ class NetworkManager_InterceptionTests : XCTestCase {
 
     // When running tests, we don't want network requests to actually work
     func testNetworkNotLive() {
-        let manager = NetworkManager(authorizationHeaderProvider: nil, baseURL: URL(string:"https://google.com")!, cache : MockResponseCache())
+        let manager = NetworkManager(authorizationDataProvider: nil, baseURL: URL(string:"https://google.com")!, cache : MockResponseCache())
 
         let apiRequest = NetworkRequest(method: HTTPMethod.GET, path: "/", deserializer : .dataResponse({_,_  -> Result<NSObject> in
             XCTFail("Shouldn't receive data")

--- a/Test/OEXFindCoursesTests.m
+++ b/Test/OEXFindCoursesTests.m
@@ -41,7 +41,7 @@
     OEXConfig *config = [[OEXConfig alloc] init];
     OEXSession *session = [[OEXSession alloc] init];
     NetworkManager *mockNetworkManager = [[NetworkManager alloc]
-                                          initWithAuthorizationHeaderProvider:NULL
+                                          initWithAuthorizationDataProvider:NULL
                                           credentialProvider:NULL
                                           baseURL:[[NSURL alloc] init]
                                           cache:[[PersistentResponseCache alloc] initWithProvider:[[SessionUsernameProvider alloc] initWithSession:session]]];

--- a/Test/RemoteImageTests.swift
+++ b/Test/RemoteImageTests.swift
@@ -9,8 +9,9 @@
 import XCTest
 @testable import edX
 
-private class StubHeaderProvider : AuthorizationHeaderProvider {
+private class StubHeaderProvider : AuthorizationHeaderProvider, SessionDataProvider {
     @objc var authorizationHeaders: [String : String] = ["test-header": "fake-value"]
+    @objc var isUserLoggedin: Bool { return true}
 }
 
 class RemoteImageTests: XCTestCase {
@@ -20,7 +21,7 @@ class RemoteImageTests: XCTestCase {
             return OHHTTPStubsResponse(error: NetworkManager.unknownError)
         }
 
-        let networkManager = NetworkManager(authorizationHeaderProvider: StubHeaderProvider(), credentialProvider: nil, baseURL: URL(string:"http://example.com")!, cache: MockResponseCache())
+        let networkManager = NetworkManager(authorizationDataProvider: StubHeaderProvider(), credentialProvider: nil, baseURL: URL(string:"http://example.com")!, cache: MockResponseCache())
 
         let remoteImage = RemoteImageImpl(url: url, networkManager: networkManager, placeholder: nil, persist: false)
 

--- a/Test/RemoteImageTests.swift
+++ b/Test/RemoteImageTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 private class StubHeaderProvider : AuthorizationHeaderProvider, SessionDataProvider {
     @objc var authorizationHeaders: [String : String] = ["test-header": "fake-value"]
-    @objc var isUserLoggedin: Bool { return true}
+    @objc var isUserLoggedin: Bool { return true }
 }
 
 class RemoteImageTests: XCTestCase {

--- a/Test/TestRouterEnvironment.swift
+++ b/Test/TestRouterEnvironment.swift
@@ -20,11 +20,14 @@ class TestRouterEnvironment : RouterEnvironment {
 
     init(
         config : OEXConfig = OEXConfig(dictionary: [:]),
-        interface: OEXInterface? = nil)
+        interface: OEXInterface? = nil,
+        user: OEXUserDetails? = nil
+    )
     {
         mockStorage = OEXMockCredentialStorage()
+        mockStorage.storedUserDetails = user
         let session = OEXSession(credentialStore: mockStorage)
-        let mockNetworkManager = MockNetworkManager(authorizationHeaderProvider: session, baseURL: NSURL(string:"http://example.com")! as URL)
+        let mockNetworkManager = MockNetworkManager(authorizationDataProvider: session, baseURL: NSURL(string:"http://example.com")! as URL)
         self.mockNetworkManager = mockNetworkManager
         eventTracker = MockAnalyticsTracker()
         mockReachability = MockReachability()

--- a/Test/UserProfileManagerTests.swift
+++ b/Test/UserProfileManagerTests.swift
@@ -17,7 +17,7 @@ class UserProfileManagerTests : XCTestCase {
         let session = OEXSession(credentialStore: credentialStorage)
         session.loadTokenFromStore()
         
-        let networkManager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: URL(string:"http://example.com")!)
+        let networkManager = MockNetworkManager(authorizationDataProvider: nil, baseURL: URL(string:"http://example.com")!)
         networkManager.interceptWhenMatching({ $0.method == .GET}, successResponse: {
             return (nil, UserProfile(username: credentialStorage.storedUserDetails!.username!))
         })

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -157,7 +157,7 @@
 		22F6A15F20BD2D06009C3F4A /* String+DecodeHTMLEntitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F6A15E20BD2D05009C3F4A /* String+DecodeHTMLEntitiesTests.swift */; };
 		22F8A9141F4708A50025E18A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22F8A9131F4708A50025E18A /* Main.storyboard */; };
 		22FDD0AC2552691600BA378D /* FirebaseRemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FDD0AB2552691600BA378D /* FirebaseRemoteConfiguration.swift */; };
-		292CBABE28AB849100A5FB96 /* NetworkManager+WaitingTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292CBABD28AB849100A5FB96 /* NetworkManager+WaitingTask.swift */; };
+		292CBABE28AB849100A5FB96 /* NetworkManager+QueuedTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292CBABD28AB849100A5FB96 /* NetworkManager+QueuedTask.swift */; };
 		3F92D6E420B1996800A69806 /* AgreementURLsConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */; };
 		3F92D6E620B19C9B00A69806 /* AgreementURLsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */; };
 		3FD829C636225A6B1FC5D32B /* libPods-edX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 44022CD0B5ABB08252788A89 /* libPods-edX.a */; };
@@ -1146,7 +1146,7 @@
 		22F6A15E20BD2D05009C3F4A /* String+DecodeHTMLEntitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+DecodeHTMLEntitiesTests.swift"; sourceTree = "<group>"; };
 		22F8A9131F4708A50025E18A /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		22FDD0AB2552691600BA378D /* FirebaseRemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseRemoteConfiguration.swift; sourceTree = "<group>"; };
-		292CBABD28AB849100A5FB96 /* NetworkManager+WaitingTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NetworkManager+WaitingTask.swift"; sourceTree = "<group>"; };
+		292CBABD28AB849100A5FB96 /* NetworkManager+QueuedTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NetworkManager+QueuedTask.swift"; sourceTree = "<group>"; };
 		2F80CBFF126E890C3709DEAF /* Pods_edXTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_edXTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AgreementURLsConfigTests.swift; path = Test/AgreementURLsConfigTests.swift; sourceTree = SOURCE_ROOT; };
 		3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgreementURLsConfig.swift; sourceTree = "<group>"; };
@@ -4020,7 +4020,7 @@
 			isa = PBXGroup;
 			children = (
 				E055D53C1D25256500230CA4 /* NetworkManager+ResponseInterceptors.swift */,
-				292CBABD28AB849100A5FB96 /* NetworkManager+WaitingTask.swift */,
+				292CBABD28AB849100A5FB96 /* NetworkManager+QueuedTask.swift */,
 				77C182AB1CD2E60E00AE1474 /* StackPaginationManipulator.swift */,
 				77E6487E1C9133C600B6740D /* SessionUsernameProvider.swift */,
 				77E6486D1C912DA200B6740D /* NetworkManager+StandardInterceptors.swift */,
@@ -5119,7 +5119,7 @@
 				5FB69A8E24BC2CD800BBCAD7 /* RegistrationFormValidation.swift in Sources */,
 				77056C3E1B3F320800D9DB4A /* DetailToolbarButton.swift in Sources */,
 				5FFCF2C7284CA12600D6456F /* LearnContainerViewController.swift in Sources */,
-				292CBABE28AB849100A5FB96 /* NetworkManager+WaitingTask.swift in Sources */,
+				292CBABE28AB849100A5FB96 /* NetworkManager+QueuedTask.swift in Sources */,
 				77691F9C1B3A0774003922F2 /* Result+JSON.swift in Sources */,
 				772619B71ADDA8ED005BD7E4 /* OEXPushSettingsManager.m in Sources */,
 				B7CCC727209B16B100A66923 /* ConstraintMakerExtendable.swift in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		22F8A9141F4708A50025E18A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22F8A9131F4708A50025E18A /* Main.storyboard */; };
 		22FDD0AC2552691600BA378D /* FirebaseRemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FDD0AB2552691600BA378D /* FirebaseRemoteConfiguration.swift */; };
 		292CBABE28AB849100A5FB96 /* NetworkManager+QueuedTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292CBABD28AB849100A5FB96 /* NetworkManager+QueuedTask.swift */; };
+		298825A528B7053100B6F448 /* OEXSession+SessionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298825A128B6323E00B6F448 /* OEXSession+SessionData.swift */; };
 		3F92D6E420B1996800A69806 /* AgreementURLsConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */; };
 		3F92D6E620B19C9B00A69806 /* AgreementURLsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */; };
 		3FD829C636225A6B1FC5D32B /* libPods-edX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 44022CD0B5ABB08252788A89 /* libPods-edX.a */; };
@@ -1147,6 +1148,7 @@
 		22F8A9131F4708A50025E18A /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		22FDD0AB2552691600BA378D /* FirebaseRemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseRemoteConfiguration.swift; sourceTree = "<group>"; };
 		292CBABD28AB849100A5FB96 /* NetworkManager+QueuedTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NetworkManager+QueuedTask.swift"; sourceTree = "<group>"; };
+		298825A128B6323E00B6F448 /* OEXSession+SessionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OEXSession+SessionData.swift"; sourceTree = "<group>"; };
 		2F80CBFF126E890C3709DEAF /* Pods_edXTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_edXTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AgreementURLsConfigTests.swift; path = Test/AgreementURLsConfigTests.swift; sourceTree = SOURCE_ROOT; };
 		3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgreementURLsConfig.swift; sourceTree = "<group>"; };
@@ -3478,6 +3480,7 @@
 			isa = PBXGroup;
 			children = (
 				77F76A6D1B0BD32A00ED3E39 /* OEXSession+Authorization.swift */,
+				298825A128B6323E00B6F448 /* OEXSession+SessionData.swift */,
 				7713DFBD1AC3C16C005A1756 /* OEXRegisteringUserDetails.h */,
 				7713DFBE1AC3C16C005A1756 /* OEXRegisteringUserDetails.m */,
 				77FFA2CA1AC35CE800B4D69B /* OEXRegistrationStyles.h */,
@@ -5261,6 +5264,7 @@
 				77D470571C11EB4D00C6F0C9 /* ChoiceLabel.swift in Sources */,
 				5F46A7CC24ADFFA300347EFC /* CourseDateViewCell.swift in Sources */,
 				77FDF4191B02910D00E8C639 /* IconMessageView.swift in Sources */,
+				298825A528B7053100B6F448 /* OEXSession+SessionData.swift in Sources */,
 				77DCD23B1C2B14BA00CAEBB5 /* UITableView+Layout.swift in Sources */,
 				B7CCC731209B16B100A66923 /* ConstraintMakerEditable.swift in Sources */,
 				22A3CECE22D31527005A046E /* APIURLVersionConfig.swift in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		22F6A15F20BD2D06009C3F4A /* String+DecodeHTMLEntitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F6A15E20BD2D05009C3F4A /* String+DecodeHTMLEntitiesTests.swift */; };
 		22F8A9141F4708A50025E18A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22F8A9131F4708A50025E18A /* Main.storyboard */; };
 		22FDD0AC2552691600BA378D /* FirebaseRemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FDD0AB2552691600BA378D /* FirebaseRemoteConfiguration.swift */; };
+		292CBABE28AB849100A5FB96 /* NetworkManager+WaitingTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292CBABD28AB849100A5FB96 /* NetworkManager+WaitingTask.swift */; };
 		3F92D6E420B1996800A69806 /* AgreementURLsConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */; };
 		3F92D6E620B19C9B00A69806 /* AgreementURLsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */; };
 		3FD829C636225A6B1FC5D32B /* libPods-edX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 44022CD0B5ABB08252788A89 /* libPods-edX.a */; };
@@ -1145,6 +1146,7 @@
 		22F6A15E20BD2D05009C3F4A /* String+DecodeHTMLEntitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+DecodeHTMLEntitiesTests.swift"; sourceTree = "<group>"; };
 		22F8A9131F4708A50025E18A /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		22FDD0AB2552691600BA378D /* FirebaseRemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseRemoteConfiguration.swift; sourceTree = "<group>"; };
+		292CBABD28AB849100A5FB96 /* NetworkManager+WaitingTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NetworkManager+WaitingTask.swift"; sourceTree = "<group>"; };
 		2F80CBFF126E890C3709DEAF /* Pods_edXTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_edXTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AgreementURLsConfigTests.swift; path = Test/AgreementURLsConfigTests.swift; sourceTree = SOURCE_ROOT; };
 		3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgreementURLsConfig.swift; sourceTree = "<group>"; };
@@ -4018,6 +4020,7 @@
 			isa = PBXGroup;
 			children = (
 				E055D53C1D25256500230CA4 /* NetworkManager+ResponseInterceptors.swift */,
+				292CBABD28AB849100A5FB96 /* NetworkManager+WaitingTask.swift */,
 				77C182AB1CD2E60E00AE1474 /* StackPaginationManipulator.swift */,
 				77E6487E1C9133C600B6740D /* SessionUsernameProvider.swift */,
 				77E6486D1C912DA200B6740D /* NetworkManager+StandardInterceptors.swift */,
@@ -5116,6 +5119,7 @@
 				5FB69A8E24BC2CD800BBCAD7 /* RegistrationFormValidation.swift in Sources */,
 				77056C3E1B3F320800D9DB4A /* DetailToolbarButton.swift in Sources */,
 				5FFCF2C7284CA12600D6456F /* LearnContainerViewController.swift in Sources */,
+				292CBABE28AB849100A5FB96 /* NetworkManager+WaitingTask.swift in Sources */,
 				77691F9C1B3A0774003922F2 /* Result+JSON.swift in Sources */,
 				772619B71ADDA8ED005BD7E4 /* OEXPushSettingsManager.m in Sources */,
 				B7CCC727209B16B100A66923 /* ConstraintMakerExtendable.swift in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-8988](https://2u-internal.atlassian.net/browse/LEARNER-8988)

This PR contains improvements for handling the expired token and making multiple requests for refreshing access token. Now application will attempt only one refresh token call and will queue the errored response request, along with queuing subsequent requests.

### How to test this PR

- [ ] Make sure we send one token refresh call.
- [ ] Queue requests that return while token needs to be refreshed.
- [ ] Resend queued requests after successful token refresh.
- [ ] Log out the user if we receive the “invalid_grant” response from the server.