### PR TITLE
[chore] add token expiry to network layer

### DIFF
--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -396,14 +396,14 @@ open class NetworkManager : NSObject {
         
         if tokenStatus == .authenticating {
             let task = QueuedTask(base: base, networkRequest: networkRequest, handler: handler)
-            appendTaskToQueue(task: task)
+            addTaskToQueue(task: task)
             return nil
         }
         
         return performTaskForRequest(base: base, networkRequest, handler: handler)
     }
     
-    private func appendTaskToQueue<Out>(task: QueuedTask<Out>) {
+    private func addTaskToQueue<Out>(task: QueuedTask<Out>) {
         let alreadyQueued = queuedTasks.contains { queuedTask in
             if let queuedTask = queuedTask as? QueuedTask<Out> {
                 return queuedTask == task
@@ -436,7 +436,7 @@ open class NetworkManager : NSObject {
                     return (result, nil)
                 case .queue:
                     let task = QueuedTask(base: base, networkRequest: networkRequest, handler: handler)
-                    self?.appendTaskToQueue(task: task)
+                    self?.addTaskToQueue(task: task)
                     let result = Box<DeserializationResult<Out>>(DeserializationResult.queuedRequest(URLRequest: URLRequest, original: data))
                     return (result, nil)
                 }

--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -366,7 +366,8 @@ open class NetworkManager : NSObject {
     @discardableResult open func taskForRequest<Out>(base: String? = nil, _ networkRequest : NetworkRequest<Out>, handler: @escaping (NetworkResult<Out>) -> Void) -> Removable? {
         
         if let tokenExpiryDate = authorizationDataProvider?.tokenExpiryDate,
-           let duration = authorizationDataProvider?.tokenExpiryDuration?.intValue {
+           let duration = authorizationDataProvider?.tokenExpiryDuration?.intValue,
+           tokenStatus != .authenticating {
             // check for token expiry date/time with the token duration from server minus 60 secs
             let tokenExpiryDate = tokenExpiryDate.add(.second, value: duration - tokenExpiryOffset)
             if tokenExpiryDate < Date() {

--- a/Source/Core/Test/Code/NetworkManagerTests.swift
+++ b/Source/Core/Test/Code/NetworkManagerTests.swift
@@ -18,8 +18,16 @@ class NetworkManagerTests: XCTestCase {
             return ["FakeHeader": "TestValue"]
         }
         
-        var isUserLoggedin: Bool {
+        var isUserLoggedIn: Bool {
             return true
+        }
+        
+        var tokenExpiryDuration: NSNumber? {
+            return 36000
+        }
+        
+        var tokenExpiryDate: Date? {
+            return Date.distantFuture
         }
     }
     

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -32,17 +32,14 @@ extension NetworkManager {
         }
         
         if let data = data,
-            let response = response
-        {
+           let response = response {
             do {
                 let raw = try JSONSerialization.jsonObject(with: data as Data, options: JSONSerialization.ReadingOptions())
                 let json = JSON(raw)
                 
                 guard let statusCode = OEXHTTPStatusCode(rawValue: response.statusCode),
-                    let error = NSError(json: json, code: response.statusCode), statusCode.is4xx else
-                {
-                    return .proceed
-                }
+                      let error = NSError(json: json, code: response.statusCode), statusCode.is4xx
+                else { return .proceed }
                 
                 guard let refreshToken = session.token?.refreshToken else {
                     return logout(router: router)
@@ -56,14 +53,15 @@ extension NetworkManager {
                     }
                 }
                 
-                if error.isAPIError(code: .OAuth2InvalidGrant) || error.isAPIError(code: .OAuth2DisabledUser) || error.isAPIError(code: .OAuth2Nonexistent) {
+                if error.isAPIError(code: .OAuth2InvalidGrant)
+                    || error.isAPIError(code: .OAuth2DisabledUser)
+                    || error.isAPIError(code: .OAuth2Nonexistent) {
                     return logout(router: router)
                 }
             }
-            catch  let error as NSError {
+            catch let error as NSError {
                 print("Failed to load: \(error.localizedDescription)")
             }
-            
         }
         
         Logger.logError("Network Authenticator", "Request failed: " + response.debugDescription)
@@ -75,17 +73,17 @@ private func logout(router:OEXRouter?) -> AuthenticationAction {
     DispatchQueue.main.async {
         router?.logout()
     }
-    return AuthenticationAction.proceed
+    return .proceed
 }
 
 /** Creates a networkRequest to refresh the access_token. If successful, the
  new access token is saved and a successful AuthenticationAction is returned.
  */
 private func refreshAccessToken(router: OEXRouter?, clientId: String, refreshToken: String, session: OEXSession) -> AuthenticationAction {
-    // Set token status refreshing
+    
     router?.environment.networkManager.tokenStatus = .authenticating
-
-    return AuthenticationAction.authenticate( { (networkManager,  completion) in
+    
+    return .authenticate { networkManager, completion in
         let networkRequest = LoginAPI.requestTokenWithRefreshToken(
             refreshToken: refreshToken,
             clientId: clientId,
@@ -94,23 +92,21 @@ private func refreshAccessToken(router: OEXRouter?, clientId: String, refreshTok
         
         networkManager.performTaskForRequest(networkRequest) { [weak networkManager] result in
             var success = false
+            
             if let currentUser = session.currentUser {
                 if let newAccessToken = result.data {
-                    session.save(newAccessToken, userDetails: currentUser)
                     success = true
+                    session.save(newAccessToken, userDetails: currentUser)
                     networkManager?.tokenStatus = .valid
                 } else {
                     networkManager?.tokenStatus = .expired
                 }
-                
-                // We need to call this method to allow tasks to callback thier handlers with success or error
-                networkManager?.performQueuedTasksIfAny(success: success)
+                networkManager?.performQueuedTasks(success: success)
             } else {
-                // Remove all queued tasks if user details are not available in session
                 networkManager?.removeAllQueuedTasks()
             }
             
             return completion(success)
         }
-    })
+    }
 }

--- a/Source/NetworkManager+QueuedTask.swift
+++ b/Source/NetworkManager+QueuedTask.swift
@@ -12,11 +12,12 @@ import edXCore
 
 extension NetworkManager {
     
-    func 
-    performQueuedTasksIfAny(success: Bool) {
+    func performQueuedTasks(success: Bool) {
         if queuedTasks.isEmpty { return }
         
-        for queuedTask in queuedTasks {
+        var iterator = queuedTasks.makeIterator()
+        
+        while let queuedTask = iterator.next() {
             switch queuedTask {
             case let task as QueuedTask<()>:
                 performTask(task: task, success: success)
@@ -121,21 +122,19 @@ extension NetworkManager {
                 Logger.logInfo(NetworkManager.NETWORK, "Unable to handle task: \(queuedTask)")
             }
         }
-        // As we have enqueued all tasks, now remove the tasks.
-        removeAllQueuedTasks()
     }
     
     func removeAllQueuedTasks() {
-        queuedTasks.removeAll()
+        queuedTasks = []
     }
     
     private func performTask<T>(task: QueuedTask<T>, success: Bool) {
         if success {
-            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication, reattempting request in queue")
+            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication success, attempting original request")
             performTaskForRequest(base: task.base, task.networkRequest, handler: task.handler)
         } else {
             let request = URLRequestWithRequest(base: task.base, task.networkRequest).value
-            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication unsuccessful so skip attempting for queued request: \(String(describing: request?.URLString))")
+            Logger.logInfo(NetworkManager.NETWORK, "Reauthentication failure, skipping request: \(String(describing: request?.URLString))")
             task.handler(NetworkResult(request: request, response: nil, data: nil, baseData: nil, error: nil))
         }
     }

--- a/Source/OEXAccessToken.h
+++ b/Source/OEXAccessToken.h
@@ -15,11 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// data should have been previously created by the -accessTokenData method
 + (OEXAccessToken* _Nullable)accessTokenWithData:(NSData*)accessTokenData;
 
-@property(nonatomic, strong, nullable) NSDate* expiryDate;
+@property(nonatomic, nullable) NSNumber* tokenExpiryDuration;
 @property(nonatomic, copy, nullable) NSString* accessToken;
 @property(nonatomic, copy, nullable) NSString* tokenType;
 @property(nonatomic, copy, nullable) NSString* scope;
 @property(nonatomic, copy, nullable) NSString* refreshToken;
+@property(nonatomic, copy, nullable) NSDate* savedOnDate;
 
 /// Provides a persistent representation of an access token
 - (NSData* _Nullable)accessTokenData;

--- a/Source/OEXAccessToken.h
+++ b/Source/OEXAccessToken.h
@@ -15,12 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// data should have been previously created by the -accessTokenData method
 + (OEXAccessToken* _Nullable)accessTokenWithData:(NSData*)accessTokenData;
 
-@property(nonatomic, nullable) NSNumber* tokenExpiryDuration;
+@property(nonatomic, nullable) NSNumber* expiryDuration;
 @property(nonatomic, copy, nullable) NSString* accessToken;
 @property(nonatomic, copy, nullable) NSString* tokenType;
 @property(nonatomic, copy, nullable) NSString* scope;
 @property(nonatomic, copy, nullable) NSString* refreshToken;
-@property(nonatomic, copy, nullable) NSDate* savedOnDate;
+@property(nonatomic, copy, nullable) NSDate* creationDate;
 
 /// Provides a persistent representation of an access token
 - (NSData* _Nullable)accessTokenData;

--- a/Source/OEXAccessToken.m
+++ b/Source/OEXAccessToken.m
@@ -14,17 +14,17 @@ static NSString* const OEXTokenTypeKey = @"token_type";
 static NSString* const OEXTokenExpiryDurationKey = @"expires_in";
 static NSString* const OEXScopeKey = @"scope";
 static NSString* const OEXRefreshTokenKey = @"refresh_token";
-static NSString* const OEXTokenSavedOnDateKey = @"token_saved_on_date";
+static NSString* const OEXTokenCreationDateKey = @"creation_date";
 
 @implementation OEXAccessToken
 
 - (id)copyWithZone:(NSZone*)zone {
     id copy = [[OEXAccessToken alloc] initWithAccessToken:self.accessToken
                                                 tokenType:self.tokenType
-                                      tokenExpiryDuration:self.tokenExpiryDuration
+                                      tokenExpiryDuration:self.expiryDuration
                                                tokenScope:self.scope
                                              refreshToken:self.refreshToken
-                                              savedOnDate:self.savedOnDate]
+                                              savedOnDate:self.creationDate]
     ;
     return copy;
 }
@@ -38,10 +38,10 @@ static NSString* const OEXTokenSavedOnDateKey = @"token_saved_on_date";
     if((self = [super init])) {
         _accessToken = [accessToken copy];
         _tokenType = [tokenType copy];
-        _tokenExpiryDuration = [tokenExpiryDuration copy];
+        _expiryDuration = [tokenExpiryDuration copy];
         _scope = [scope copy];
         _refreshToken = [refreshToken copy];
-        _savedOnDate = [savedOnDate copy];
+        _creationDate = [savedOnDate copy];
     }
 
     return self;
@@ -52,10 +52,10 @@ static NSString* const OEXTokenSavedOnDateKey = @"token_saved_on_date";
     if(self) {
         _accessToken = [dict objectForKey:OEXAccessTokenKey];
         _tokenType = [dict objectForKey:OEXTokenTypeKey];
-        _tokenExpiryDuration = [dict objectForKey:OEXTokenExpiryDurationKey];
+        _expiryDuration = [dict objectForKey:OEXTokenExpiryDurationKey];
         _scope = [dict objectForKey:OEXScopeKey];
         _refreshToken = [dict objectForKey:OEXRefreshTokenKey];
-        _savedOnDate = [dict objectForKey:OEXTokenSavedOnDateKey];
+        _creationDate = [NSDate now];
         if(!_accessToken) {
             self = nil;
         }
@@ -69,10 +69,10 @@ static NSString* const OEXTokenSavedOnDateKey = @"token_saved_on_date";
     if(_accessToken) {
         [dict setSafeObject:_accessToken forKey:OEXAccessTokenKey];
         [dict setObjectOrNil:_tokenType forKey:OEXTokenTypeKey];
-        [dict setObjectOrNil:_tokenExpiryDuration forKey:OEXTokenExpiryDurationKey];
+        [dict setObjectOrNil:_expiryDuration forKey:OEXTokenExpiryDurationKey];
         [dict setObjectOrNil:_scope forKey:OEXScopeKey];
         [dict setObjectOrNil:_refreshToken forKey:OEXRefreshTokenKey];
-        [dict setObjectOrNil:[NSDate now] forKey:OEXTokenSavedOnDateKey];
+        [dict setObjectOrNil:[NSDate now] forKey:OEXTokenCreationDateKey];
     }
     else {
         return nil;
@@ -103,10 +103,10 @@ static NSString* const OEXTokenSavedOnDateKey = @"token_saved_on_date";
     }
     token.accessToken = dictionaryAccessToken;
     token.tokenType = accessTokenDictionary[OEXTokenTypeKey];
-    token.tokenExpiryDuration = accessTokenDictionary[OEXTokenExpiryDurationKey];
+    token.expiryDuration = accessTokenDictionary[OEXTokenExpiryDurationKey];
     token.scope = accessTokenDictionary[OEXScopeKey];
     token.refreshToken = accessTokenDictionary[OEXRefreshTokenKey];
-    token.savedOnDate = accessTokenDictionary[OEXTokenSavedOnDateKey];
+    token.creationDate = accessTokenDictionary[OEXTokenCreationDateKey];
     return token;
 }
 

--- a/Source/OEXAccessToken.m
+++ b/Source/OEXAccessToken.m
@@ -11,33 +11,37 @@
 
 static NSString* const OEXAccessTokenKey = @"access_token";
 static NSString* const OEXTokenTypeKey = @"token_type";
-static NSString* const OEXExpiryDateKey = @"expires_in";
+static NSString* const OEXTokenExpiryDurationKey = @"expires_in";
 static NSString* const OEXScopeKey = @"scope";
 static NSString* const OEXRefreshTokenKey = @"refresh_token";
+static NSString* const OEXTokenSavedOnDateKey = @"token_saved_on_date";
 
 @implementation OEXAccessToken
 
 - (id)copyWithZone:(NSZone*)zone {
     id copy = [[OEXAccessToken alloc] initWithAccessToken:self.accessToken
                                                 tokenType:self.tokenType
-                                               expiryDate:self.expiryDate
+                                      tokenExpiryDuration:self.tokenExpiryDuration
                                                tokenScope:self.scope
-                                             refreshToken:self.refreshToken]
+                                             refreshToken:self.refreshToken
+                                              savedOnDate:self.savedOnDate]
     ;
     return copy;
 }
 
 - (id)initWithAccessToken:(NSString*)accessToken
                 tokenType:(NSString*)tokenType
-               expiryDate:(NSDate*)expiryDate
+      tokenExpiryDuration:(NSNumber*)tokenExpiryDuration
                tokenScope:(NSString*)scope
-             refreshToken:(NSString*)refreshToken {
+             refreshToken:(NSString*)refreshToken
+              savedOnDate:(NSDate*)savedOnDate {
     if((self = [super init])) {
         _accessToken = [accessToken copy];
         _tokenType = [tokenType copy];
-        _expiryDate = [expiryDate copy];
+        _tokenExpiryDuration = [tokenExpiryDuration copy];
         _scope = [scope copy];
         _refreshToken = [refreshToken copy];
+        _savedOnDate = [savedOnDate copy];
     }
 
     return self;
@@ -48,9 +52,10 @@ static NSString* const OEXRefreshTokenKey = @"refresh_token";
     if(self) {
         _accessToken = [dict objectForKey:OEXAccessTokenKey];
         _tokenType = [dict objectForKey:OEXTokenTypeKey];
-        _expiryDate = [dict objectForKey:OEXExpiryDateKey];
+        _tokenExpiryDuration = [dict objectForKey:OEXTokenExpiryDurationKey];
         _scope = [dict objectForKey:OEXScopeKey];
         _refreshToken = [dict objectForKey:OEXRefreshTokenKey];
+        _savedOnDate = [dict objectForKey:OEXTokenSavedOnDateKey];
         if(!_accessToken) {
             self = nil;
         }
@@ -64,9 +69,10 @@ static NSString* const OEXRefreshTokenKey = @"refresh_token";
     if(_accessToken) {
         [dict setSafeObject:_accessToken forKey:OEXAccessTokenKey];
         [dict setObjectOrNil:_tokenType forKey:OEXTokenTypeKey];
-        [dict setObjectOrNil:_expiryDate forKey:OEXExpiryDateKey];
+        [dict setObjectOrNil:_tokenExpiryDuration forKey:OEXTokenExpiryDurationKey];
         [dict setObjectOrNil:_scope forKey:OEXScopeKey];
         [dict setObjectOrNil:_refreshToken forKey:OEXRefreshTokenKey];
+        [dict setObjectOrNil:[NSDate now] forKey:OEXTokenSavedOnDateKey];
     }
     else {
         return nil;
@@ -97,9 +103,10 @@ static NSString* const OEXRefreshTokenKey = @"refresh_token";
     }
     token.accessToken = dictionaryAccessToken;
     token.tokenType = accessTokenDictionary[OEXTokenTypeKey];
-    token.expiryDate = accessTokenDictionary[OEXExpiryDateKey];
+    token.tokenExpiryDuration = accessTokenDictionary[OEXTokenExpiryDurationKey];
     token.scope = accessTokenDictionary[OEXScopeKey];
     token.refreshToken = accessTokenDictionary[OEXRefreshTokenKey];
+    token.savedOnDate = accessTokenDictionary[OEXTokenSavedOnDateKey];
     return token;
 }
 

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -120,6 +120,7 @@
                                             userPreferenceManager:userPreferenceManager
                     ];
         };
+        __weak typeof(self) weakSelf = self;
         self.networkManagerBuilder = ^(OEXEnvironment* env) {
             PersistentResponseCache* cache = [[PersistentResponseCache alloc] initWithProvider: [[SessionUsernameProvider alloc] initWithSession:env.session]];
             NetworkManager* manager = [[NetworkManager alloc]
@@ -131,6 +132,7 @@
                 [manager addStandardInterceptors];
                 [manager addResponseInterceptors];
                 [manager addRefreshTokenAuthenticatorWithRouter:env.router session:env.session clientId:env.config.oauthClientID];
+                [weakSelf.session loadTokenFromStore];
             }];
             return manager;
         };
@@ -154,11 +156,7 @@
             return [[OEXStyles alloc] init];
         };
         self.sessionBuilder = ^(OEXEnvironment* env){
-            OEXSession* session = [[OEXSession alloc] init];
-            [env.postSetupActions addObject: ^(OEXEnvironment* env) {
-                [env.session loadTokenFromStore];
-            }];
-            return session;
+            return [[OEXSession alloc] init];
         };
         
         self.remoteConfigBuilder = ^(OEXEnvironment* env){

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -120,7 +120,6 @@
                                             userPreferenceManager:userPreferenceManager
                     ];
         };
-        __weak typeof(self) weakSelf = self;
         self.networkManagerBuilder = ^(OEXEnvironment* env) {
             PersistentResponseCache* cache = [[PersistentResponseCache alloc] initWithProvider: [[SessionUsernameProvider alloc] initWithSession:env.session]];
             NetworkManager* manager = [[NetworkManager alloc]
@@ -132,7 +131,7 @@
                 [manager addStandardInterceptors];
                 [manager addResponseInterceptors];
                 [manager addRefreshTokenAuthenticatorWithRouter:env.router session:env.session clientId:env.config.oauthClientID];
-                [weakSelf.session loadTokenFromStore];
+                [env.session loadTokenFromStore];
             }];
             return manager;
         };

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -564,13 +564,12 @@ extension OEXRouter {
         showLoggedOutScreen()
     }
     
-    func invalidateToken() {        
+    func invalidateToken() {
         if let refreshToken = environment.session.token?.refreshToken, let clientID = environment.config.oauthClientID() {
             let networkRequest = LogoutApi.invalidateToken(refreshToken: refreshToken, clientID: clientID)
-            environment.networkManager.taskForRequest(networkRequest) { [weak self] result in
-                self?.environment.networkManager.tokenStatus = .prelogin
-            }
+            environment.networkManager.taskForRequest(networkRequest) { _ in }
         }
+        environment.networkManager.tokenStatus = .prelogin
     }
 
     // MARK: - Debug

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -558,7 +558,6 @@ extension OEXRouter {
     }
     
     @objc public func logout() {
-        environment.networkManager.tokenStatus = .invalid
         invalidateToken()
         environment.session.closeAndClear()
         environment.session.removeAllWebData()
@@ -566,6 +565,8 @@ extension OEXRouter {
     }
     
     func invalidateToken() {
+        environment.networkManager.tokenStatus = .prelogin
+        
         if let refreshToken = environment.session.token?.refreshToken, let clientID = environment.config.oauthClientID() {
             let networkRequest = LogoutApi.invalidateToken(refreshToken: refreshToken, clientID: clientID)
             environment.networkManager.taskForRequest(networkRequest) { result in }

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -564,12 +564,12 @@ extension OEXRouter {
         showLoggedOutScreen()
     }
     
-    func invalidateToken() {
-        environment.networkManager.tokenStatus = .prelogin
-        
+    func invalidateToken() {        
         if let refreshToken = environment.session.token?.refreshToken, let clientID = environment.config.oauthClientID() {
             let networkRequest = LogoutApi.invalidateToken(refreshToken: refreshToken, clientID: clientID)
-            environment.networkManager.taskForRequest(networkRequest) { result in }
+            environment.networkManager.taskForRequest(networkRequest) { [weak self] result in
+                self?.environment.networkManager.tokenStatus = .prelogin
+            }
         }
     }
 

--- a/Source/OEXSession+SessionData.swift
+++ b/Source/OEXSession+SessionData.swift
@@ -14,10 +14,10 @@ extension OEXSession: SessionDataProvider {
     }
     
     public var tokenExpiryDuration: NSNumber? {
-        return token?.tokenExpiryDuration
+        return token?.expiryDuration
     }
     
     public var tokenExpiryDate: Date? {
-        return token?.savedOnDate
+        return token?.creationDate
     }
 }

--- a/Source/OEXSession+SessionData.swift
+++ b/Source/OEXSession+SessionData.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension OEXSession: SessionDataProvider {
     public var isUserLoggedIn: Bool {
-        return currentUser != nil
+        return containsUserDetails()
     }
     
     public var tokenExpiryDuration: NSNumber? {

--- a/Source/OEXSession+SessionData.swift
+++ b/Source/OEXSession+SessionData.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension OEXSession: SessionDataProvider {
     public var isUserLoggedIn: Bool {
-        return containsUserDetails()
+        return userExists()
     }
     
     public var tokenExpiryDuration: NSNumber? {

--- a/Source/OEXSession+SessionData.swift
+++ b/Source/OEXSession+SessionData.swift
@@ -9,7 +9,15 @@
 import Foundation
 
 extension OEXSession: SessionDataProvider {
-    public var isUserLoggedin: Bool {
-        return doesUserDetailsExist()
+    public var isUserLoggedIn: Bool {
+        return currentUser != nil
+    }
+    
+    public var tokenExpiryDuration: NSNumber? {
+        return token?.tokenExpiryDuration
+    }
+    
+    public var tokenExpiryDate: Date? {
+        return token?.savedOnDate
     }
 }

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -38,7 +38,7 @@ extern NSString* const OEXSessionEndedNotification;
 /// When registration is sucssessful, this token is removed.
 @property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
 
-- (BOOL)containsUserDetails;
+- (BOOL)userExists;
 - (void)loadTokenFromStore;
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails;
 - (void)closeAndClearSession;

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -38,6 +38,7 @@ extern NSString* const OEXSessionEndedNotification;
 /// When registration is sucssessful, this token is removed.
 @property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
 
+- (BOOL)containsUserDetails;
 - (void)loadTokenFromStore;
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails;
 - (void)closeAndClearSession;

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -38,7 +38,6 @@ extern NSString* const OEXSessionEndedNotification;
 /// When registration is sucssessful, this token is removed.
 @property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
 
-- (BOOL)doesUserDetailsExist;
 - (void)loadTokenFromStore;
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails;
 - (void)closeAndClearSession;

--- a/Source/OEXSession.m
+++ b/Source/OEXSession.m
@@ -57,9 +57,11 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
 }
 
 - (id)init {
-    self = [self initWithCredentialStore:[[OEXPersistentCredentialStorage alloc] init]];
-    [self loadTokenFromStore];
-    return self;
+    return [self initWithCredentialStore:[[OEXPersistentCredentialStorage alloc] init]];
+}
+
+- (BOOL)containsUserDetails {
+    return self.credentialStore.storedUserDetails != nil;
 }
 
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails {
@@ -75,20 +77,16 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
 }
 
 - (void)loadTokenFromStore {
-    if (self.token && self.currentUser) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : self.currentUser}];
-    } else {
-        OEXAccessToken* tokenData = self.credentialStore.storedAccessToken;
-        OEXUserDetails* userDetails = self.credentialStore.storedUserDetails;
+    OEXAccessToken* tokenData = self.credentialStore.storedAccessToken;
+    OEXUserDetails* userDetails = self.credentialStore.storedUserDetails;
 
-        if(tokenData && userDetails) {
-            self.token = tokenData;
-            self.currentUser = userDetails;
-            [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : userDetails}];
-        }
-        else {
-            [self.credentialStore clear];
-        }
+    if(tokenData && userDetails) {
+        self.token = tokenData;
+        self.currentUser = userDetails;
+        [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : userDetails}];
+    }
+    else {
+        [self.credentialStore clear];
     }
 }
 

--- a/Source/OEXSession.m
+++ b/Source/OEXSession.m
@@ -57,7 +57,9 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
 }
 
 - (id)init {
-    return [self initWithCredentialStore:[[OEXPersistentCredentialStorage alloc] init]];
+    self = [self initWithCredentialStore:[[OEXPersistentCredentialStorage alloc] init]];
+    [self loadTokenFromStore];
+    return self;
 }
 
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails {
@@ -72,21 +74,21 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
     self.thirdPartyAuthAccessToken = nil;
 }
 
-- (BOOL)doesUserDetailsExist {
-    return self.credentialStore.storedUserDetails != nil;
-}
-
 - (void)loadTokenFromStore {
-    OEXAccessToken* tokenData = self.credentialStore.storedAccessToken;
-    OEXUserDetails* userDetails = self.credentialStore.storedUserDetails;
+    if (self.token && self.currentUser) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : self.currentUser}];
+    } else {
+        OEXAccessToken* tokenData = self.credentialStore.storedAccessToken;
+        OEXUserDetails* userDetails = self.credentialStore.storedUserDetails;
 
-    if(tokenData && userDetails) {
-        self.token = tokenData;
-        self.currentUser = userDetails;
-        [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : userDetails}];
-    }
-    else {
-        [self.credentialStore clear];
+        if(tokenData && userDetails) {
+            self.token = tokenData;
+            self.currentUser = userDetails;
+            [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : userDetails}];
+        }
+        else {
+            [self.credentialStore clear];
+        }
     }
 }
 

--- a/Source/OEXSession.m
+++ b/Source/OEXSession.m
@@ -60,7 +60,7 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
     return [self initWithCredentialStore:[[OEXPersistentCredentialStorage alloc] init]];
 }
 
-- (BOOL)containsUserDetails {
+- (BOOL)userExists {
     return self.credentialStore.storedUserDetails != nil;
 }
 

--- a/Test/OEXMockCredentialStorage.m
+++ b/Test/OEXMockCredentialStorage.m
@@ -17,7 +17,7 @@
 + (instancetype)fakeToken {
     OEXAccessToken* token = [[OEXAccessToken alloc] init];
     token.accessToken = [NSUUID UUID].UUIDString;
-    token.expiryDate = [[NSDate date] dateByAddingDays:1];
+    token.tokenExpiryDuration = @36000;
     token.scope = @"sample scope";
     token.tokenType = @"sample type";
     return token;

--- a/Test/OEXMockCredentialStorage.m
+++ b/Test/OEXMockCredentialStorage.m
@@ -17,7 +17,7 @@
 + (instancetype)fakeToken {
     OEXAccessToken* token = [[OEXAccessToken alloc] init];
     token.accessToken = [NSUUID UUID].UUIDString;
-    token.tokenExpiryDuration = @36000;
+    token.expiryDuration = @36000;
     token.scope = @"sample scope";
     token.tokenType = @"sample type";
     return token;

--- a/Test/OEXSessionTests.m
+++ b/Test/OEXSessionTests.m
@@ -186,7 +186,7 @@
 - (void)testMigrationClearSessionStorage {
     OEXAccessToken* token = [[OEXAccessToken alloc] init];
     token.accessToken = @"some token";
-    token.expiryDate = [NSDate date];
+    token.tokenExpiryDuration = @36000;
     token.scope = @"sample scope";
     
     OEXUserDetails* userDetails = [[OEXUserDetails alloc] init];

--- a/Test/OEXSessionTests.m
+++ b/Test/OEXSessionTests.m
@@ -186,7 +186,7 @@
 - (void)testMigrationClearSessionStorage {
     OEXAccessToken* token = [[OEXAccessToken alloc] init];
     token.accessToken = @"some token";
-    token.tokenExpiryDuration = @36000;
+    token.expiryDuration = @36000;
     token.scope = @"sample scope";
     
     OEXUserDetails* userDetails = [[OEXUserDetails alloc] init];

--- a/Test/RemoteImageTests.swift
+++ b/Test/RemoteImageTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 private class StubHeaderProvider : AuthorizationHeaderProvider, SessionDataProvider {
     @objc var authorizationHeaders: [String : String] = ["test-header": "fake-value"]
-    @objc var isUserLoggedin: Bool { return true }
+    @objc var isUserLoggedIn: Bool { return true }
+    var tokenExpiryDuration: NSNumber? { return 36000 }
+    var tokenExpiryDate: Date? { return Date.distantFuture }
 }
 
 class RemoteImageTests: XCTestCase {


### PR DESCRIPTION
### Description

[LEARNER-8968](https://2u-internal.atlassian.net/browse/LEARNER-8968)

This PR applies token expiry to the network requests before a network call is made. The expiry duration is saved and it is applied before a network request is queued. 
