### PR TITLE
[chore] Handle Duplicate Transactions ID Gracefully

### DIFF
--- a/Source/CourseUpgradeHelper.swift
+++ b/Source/CourseUpgradeHelper.swift
@@ -166,7 +166,7 @@ class CourseUpgradeHelper: NSObject {
 
         let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.FailureAlert.alertTitle, message: upgradeHadler?.errorMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
 
-        if case .error (let type, _) = upgradeHadler?.state, type == .verifyReceiptError {
+        if case .error (let type, let error) = upgradeHadler?.state, type == .verifyReceiptError && error?.errorCode != 409 {
             alertController.addButton(withTitle: Strings.CourseUpgrade.FailureAlert.refreshToRetry, style: .default) { [weak self] _ in
                 self?.trackUpgradeErrorAction(errorAction: ErrorAction.refreshToRetry)
                 self?.refreshTime = CFAbsoluteTimeGetCurrent()
@@ -442,4 +442,8 @@ class InappPurchase: NSObject, NSCoding {
     }
 }
 
-
+extension Error {
+    var errorCode:Int? {
+        return (self as NSError).code
+    }
+}

--- a/Source/PaymentManager.swift
+++ b/Source/PaymentManager.swift
@@ -27,7 +27,6 @@ enum PurchaseError: String {
     case checkoutError // checkout API returns error
     case verifyReceiptError // verify receipt API returns error
     case generalError // general error
-    case alreadyPurchased // Course is already purchased on the same device
     case sdnError // If user does not opt-in SDN checklist
     
     var errorString: String {


### PR DESCRIPTION
### Description

[LEARNER-9007](https://2u-internal.atlassian.net/browse/LEARNER-9007)

This PR stops stop an edX user logged in the app from restoring purchases of another edX user logged in the AppStore on the same device.

### How to test this PR

* Sign in with edX app user A, make a payment for a course e.g Demo Course and logout
* Sign in with another edX app user B who enrolled in the same course Demo Course on the same device
* Try to upgrade the course, App store will return information for the old transaction.
* App Should give an error like course has been paid by another user on the same device.
