### PR TITLE
[fix] Hide cross button in the video download quality selection screen

### DIFF
--- a/Source/VideoDownloadQualityViewController.swift
+++ b/Source/VideoDownloadQualityViewController.swift
@@ -57,7 +57,9 @@ class VideoDownloadQualityViewController: UIViewController {
         title = Strings.videoDownloadQualityTitle
         
         setupViews()
-        addCloseButton()
+        if isModal() {
+            addCloseButton()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### Description

[LEARNER-9013](https://2u-internal.atlassian.net/browse/LEARNER-9013)

Hide Cross button in the video download quality selection screen when accessed from the profile screen

