### PR TITLE
[fix] empty network request queue after making requests

### DIFF
--- a/Source/NetworkManager+QueuedTask.swift
+++ b/Source/NetworkManager+QueuedTask.swift
@@ -122,6 +122,7 @@ extension NetworkManager {
                 Logger.logInfo(NetworkManager.NETWORK, "Unable to handle task: \(queuedTask)")
             }
         }
+        removeAllQueuedTasks()
     }
     
     func removeAllQueuedTasks() {


### PR DESCRIPTION
### Description

[LEARNER-9050](https://2u-internal.atlassian.net/browse/LEARNER-9050)

This PR removes elements from network request queue after making pending network requests.