### PR TITLE
[chore] IAP and IAP Experiment flags for handling of treatment and  control for IAP experiment

### DIFF
--- a/Source/CourseUpgradeButtonView.swift
+++ b/Source/CourseUpgradeButtonView.swift
@@ -9,8 +9,8 @@
 import UIKit
 
 class CourseUpgradeButtonView: UIView, ShimmerView {
-    static var height: CGFloat = {
-        return OEXConfig.shared().inappPurchasesEnabled ? 36 : 0
+    var height: CGFloat = {
+        return (ServerConfiguration.shared.iapConfig?.enabledforUser ?? false) ? 36 : 0
     }()
         
     private lazy var titleLabel: UILabel = {
@@ -60,7 +60,7 @@ class CourseUpgradeButtonView: UIView, ShimmerView {
         isAccessibilityElement = true
         accessibilityHint = Strings.Accessibility.upgradeButtonHint
         
-        isHidden = OEXConfig.shared().inappPurchasesEnabled
+        isHidden = ServerConfiguration.shared.iapConfig?.enabledforUser ?? false
     }
     
     private func addConstraints() {

--- a/Source/CourseUpgradeButtonView.swift
+++ b/Source/CourseUpgradeButtonView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class CourseUpgradeButtonView: UIView, ShimmerView {
     var height: CGFloat = {
-        return (ServerConfiguration.shared.iapConfig?.enabledforUser ?? false) ? 36 : 0
+        return ServerConfiguration.shared.iapConfig?.enabledforUser ?? false ? 36 : 0
     }()
         
     private lazy var titleLabel: UILabel = {

--- a/Source/OEXAnalytics+CourseUpgrade.swift
+++ b/Source/OEXAnalytics+CourseUpgrade.swift
@@ -21,7 +21,7 @@ extension OEXAnalytics {
         let info = [
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screenName.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screenName.rawValue,
             key_course_id: courseID,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
         ]
@@ -40,7 +40,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
         ]
 
@@ -57,7 +57,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
             AnalyticsEventDataKey.ElapsedTime.rawValue: "\(elapsedTime)",
         ]
@@ -75,7 +75,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
             AnalyticsEventDataKey.ElapsedTime.rawValue: "\(elapsedTime)",
         ]
@@ -93,7 +93,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
             AnalyticsEventDataKey.UpgradeError.rawValue: paymentError,
         ]
@@ -111,7 +111,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID,
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
             AnalyticsEventDataKey.UpgradeError.rawValue: upgradeError,
         ]
@@ -129,7 +129,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
         ]
 
         trackEvent(event, forComponent: nil, withInfo: info)
@@ -145,7 +145,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
             AnalyticsEventDataKey.ErrorAction.rawValue: errorAction,
             AnalyticsEventDataKey.UpgradeError.rawValue: upgradeError,
@@ -164,7 +164,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: price,
             AnalyticsEventDataKey.ElapsedTime.rawValue: "\(elapsedTime)",
         ]
@@ -182,7 +182,7 @@ extension OEXAnalytics {
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID,
             AnalyticsEventDataKey.ComponentID.rawValue: blockID ?? "",
-            AnalyticsEventDataKey.ScreenName.rawValue: screen.text,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
             AnalyticsEventDataKey.Price.rawValue: coursePrice,
             AnalyticsEventDataKey.ElapsedTime.rawValue: "\(elapsedTime)",
         ]

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -29,6 +29,7 @@ public enum AnalyticsDisplayName : String {
     case ValuePropLockedContentClicked = "Value Prop Locked Content Clicked"
     case ValuePropShowMoreClicked = "Value Prop Show More Clicked"
     case ValuePropShowLessClicked = "Value Prop Show Less Clicked"
+    case ValuePropMessageViewed = "Value Prop Message Viewed"
     case CreateAccount = "Create Account Clicked"
     case RegistrationSuccess = "Registration Success"
     case EnrolledCourseClicked = "Course Enroll Clicked"
@@ -92,9 +93,9 @@ public enum AnalyticsDisplayName : String {
     case CourseUpgradeError = "Payments: Course Upgrade Error"
     case CourseUpgradeLoadError = "Payments: Price Load Error"
     case CourseUpgradeErrorAction = "Payments: Error Alert Action"
+    case SDNPromptAction = "Payments: SDN Prompt Action"
     case DiscoverExternalLinkOpenAlert = "Discovery: External Link Opening Alert"
     case DiscoverExternalLinkOpenAlertAction = "Discovery: External Link Opening Alert Action"
-    case SDNPromptAction = "Payments: SDN Prompt Action"
 }
 
 public enum AnalyticsEventName: String {
@@ -108,6 +109,7 @@ public enum AnalyticsEventName: String {
     case ValuePropLockedContentClicked = "edx.bi.app.course.unit.locked.content.clicked"
     case ValuePropShowMoreClicked = "edx.bi.app.value_prop.show_more.clicked"
     case ValuePropShowLessClicked = "edx.bi.app.value_prop.show_less.clicked"
+    case ValuePropMessageViewed = "edx.bi.app.value_prop_message.viewed"
     case ViewRating = "edx.bi.app.app_reviews.view_rating"
     case DismissRating = "edx.bi.app.app_reviews.dismiss_rating"
     case SubmitRating = "edx.bi.app.app_reviews.submit_rating"
@@ -239,6 +241,8 @@ public enum AnalyticsEventDataKey: String {
     case UpgradeError = "error"
     case ErrorAction = "error_action"
     case Action = "action"
+    case IAPExperiementGroup = "iap_experiment_group"
+    case PaymentsEnabled = "payment_enabled"
 }
 
 extension OEXAnalytics {
@@ -427,6 +431,26 @@ extension OEXAnalytics {
             key_course_id: courseID
         ]
 
+        trackEvent(event, forComponent: nil, withInfo: info)
+    }
+    
+    func trackValuePropMessageViewed(courseID: String, blockID: String? = nil, paymentsEnabled: Bool, iapExperiementEnabled: Bool, group: IAPExperiementGroup? = nil, screen: CourseUpgradeScreen) {
+        let event = OEXAnalyticsEvent()
+        event.displayName = AnalyticsDisplayName.ValuePropMessageViewed.rawValue
+        event.name = AnalyticsEventName.ValuePropMessageViewed.rawValue
+        
+        var info: [String : Any] = [
+            key_course_id: courseID,
+            AnalyticsEventDataKey.ScreenName.rawValue: screen.rawValue,
+            AnalyticsEventDataKey.PaymentsEnabled.rawValue: paymentsEnabled
+        ]
+        
+        info.setObjectOrNil(blockID, forKey: AnalyticsEventDataKey.ComponentID.rawValue)
+        
+        if iapExperiementEnabled {
+            info.setObjectOrNil(group?.rawValue, forKey: AnalyticsEventDataKey.IAPExperiementGroup.rawValue)
+        }
+        
         trackEvent(event, forComponent: nil, withInfo: info)
     }
     

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -84,12 +84,9 @@
     [self.environment.session performMigrations];
     [self.environment.router openInWindow:self.window];
     [self configureBranch:launchOptions];
-        
-    [[FBSDKApplicationDelegate sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+    [[PaymentManager shared] completeTransactions];
 
-    if (self.environment.config.inappPurchasesEnabled) {
-        [[PaymentManager shared] completeTransactions];
-    }
+    [[FBSDKApplicationDelegate sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
 
     return YES;
 }

--- a/Source/OEXConfig+AppFeatures.swift
+++ b/Source/OEXConfig+AppFeatures.swift
@@ -82,8 +82,4 @@ extension OEXConfig {
         }
         return false
     }
-
-    @objc var inappPurchasesEnabled: Bool {
-        return bool(forKey: "IAP_ENABLED") && ecommerceURL != nil
-    }
 }

--- a/Source/ProfileOptionsViewController.swift
+++ b/Source/ProfileOptionsViewController.swift
@@ -25,7 +25,7 @@ class ProfileOptionsViewController: UIViewController {
         case deleteAccount
     }
     
-    typealias Environment = OEXStylesProvider & OEXConfigProvider & NetworkManagerProvider & DataManagerProvider & OEXRouterProvider & OEXSessionProvider & OEXInterfaceProvider & OEXAnalyticsProvider
+    typealias Environment = OEXStylesProvider & OEXConfigProvider & NetworkManagerProvider & DataManagerProvider & OEXRouterProvider & OEXSessionProvider & OEXInterfaceProvider & OEXAnalyticsProvider & ServerConfigProvider
     
     let environment: Environment
     
@@ -141,7 +141,7 @@ class ProfileOptionsViewController: UIViewController {
             options.append(.personalInformation)
         }
         
-        if environment.config.inappPurchasesEnabled {
+        if environment.serverConfig.iapConfig?.enabled ?? false {
             options.append(.restorePurchase)
         }
         

--- a/Source/ServerConfiguration.swift
+++ b/Source/ServerConfiguration.swift
@@ -48,6 +48,11 @@ public extension ServerConfigProvider {
     }
 }
 
+enum IAPExperiementGroup: String {
+    case control
+    case treatment
+}
+
 class IAPConfig: NSObject {
 
     enum Keys: String, RawStringExtractable {
@@ -69,6 +74,14 @@ class IAPConfig: NSObject {
         }
 
         return enabled
+    }
+    
+    var experimentGroup: IAPExperiementGroup? {
+        if experimentEnabled && enabled {
+            return OEXSession.shared()?.currentUser?.isFromControlGroup ?? false ? .control : .treatment
+        }
+        
+        return nil
     }
 }
 

--- a/Source/ServerConfiguration.swift
+++ b/Source/ServerConfiguration.swift
@@ -65,9 +65,9 @@ class IAPConfig: NSObject {
 
     var enabledforUser: Bool {
         if experimentEnabled {
-            return enabled && experimentEnabled && !(OEXSession.shared()?.currentUser?.isFromControlGroup ?? true)
+            return enabled && !(OEXSession.shared()?.currentUser?.isFromControlGroup ?? true)
         }
-        
+
         return enabled
     }
 }

--- a/Source/ServerConfiguration.swift
+++ b/Source/ServerConfiguration.swift
@@ -64,7 +64,11 @@ class IAPConfig: NSObject {
     }
 
     var enabledforUser: Bool {
-        return enabled && experimentEnabled && !(OEXSession.shared()?.currentUser?.isFromControlGroup ?? true)
+        if experimentEnabled {
+            return enabled && experimentEnabled && !(OEXSession.shared()?.currentUser?.isFromControlGroup ?? true)
+        }
+        
+        return enabled
     }
 }
 

--- a/Source/ServerConfiguration.swift
+++ b/Source/ServerConfiguration.swift
@@ -22,11 +22,13 @@ public extension ServerConfigProvider {
     private enum Keys: String, RawStringExtractable {
         case valuePropEnabled = "value_prop_enabled"
         case config = "config"
+        case iapConfig = "iap_config"
     }
     
     @objc static let shared = ServerConfiguration()
     
     private(set) var valuePropEnabled: Bool = false
+    private(set) var iapConfig: IAPConfig? = nil
     
     private override init() {
         super.init()
@@ -39,5 +41,36 @@ public extension ServerConfigProvider {
               let config = try? JSONSerialization.jsonObject(with: configData, options : []) as? Dictionary<String,Any> else { return }
 
         valuePropEnabled = config[Keys.valuePropEnabled] as? Bool ?? false
+
+        if let iapDict = config[Keys.iapConfig] as? Dictionary<String, Any> {
+            iapConfig = IAPConfig(dictionary: iapDict)
+        }
+    }
+}
+
+class IAPConfig: NSObject {
+
+    enum Keys: String, RawStringExtractable {
+        case enabled = "enebled"
+        case experimentEnabled = "experiment_enabled"
+    }
+
+    private(set) var enabled: Bool = false
+    private(set) var experimentEnabled: Bool = false
+
+    init(dictionary: Dictionary<String, Any>) {
+        enabled = dictionary[Keys.enabled] as? Bool ?? false
+        experimentEnabled = dictionary[Keys.experimentEnabled] as? Bool ?? false
+    }
+
+    var enabledforUser: Bool {
+        return enabled && experimentEnabled && !(OEXSession.shared()?.currentUser?.isFromControlGroup ?? true)
+    }
+}
+
+extension OEXUserDetails {
+    var isFromControlGroup: Bool {
+        guard let userID = userId?.intValue else { return true }
+        return userID % 2 == 0
     }
 }

--- a/Source/ServerConfiguration.swift
+++ b/Source/ServerConfiguration.swift
@@ -51,7 +51,7 @@ public extension ServerConfigProvider {
 class IAPConfig: NSObject {
 
     enum Keys: String, RawStringExtractable {
-        case enabled = "enebled"
+        case enabled = "enabled"
         case experimentEnabled = "experiment_enabled"
     }
 

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -15,7 +15,7 @@ protocol ValuePropMessageViewDelegate: AnyObject {
 
 class ValuePropComponentView: UIView {
     
-    typealias Environment = OEXStylesProvider & DataManagerProvider & OEXAnalyticsProvider
+    typealias Environment = OEXStylesProvider & DataManagerProvider & OEXAnalyticsProvider & ServerConfigProvider
         
     weak var delegate: ValuePropMessageViewDelegate?
         
@@ -90,6 +90,7 @@ class ValuePropComponentView: UIView {
         setupViews()
         setConstraints()
         setAccessibilityIdentifiers()
+        trackValuePropMessageViewed()
     }
     
     required init?(coder: NSCoder) {
@@ -196,6 +197,14 @@ class ValuePropComponentView: UIView {
                 }
             }
         }
+    }
+    
+    private func trackValuePropMessageViewed() {
+        guard let courseID = course?.course_id else { return }
+        let paymentsEnabled = (environment.serverConfig.iapConfig?.enabled ?? false) && course?.sku != nil
+        let iapExperiementEnabled = environment.serverConfig.iapConfig?.experimentEnabled ?? false
+        let group = environment.serverConfig.iapConfig?.experimentGroup
+        environment.analytics.trackValuePropMessageViewed(courseID: courseID, paymentsEnabled: paymentsEnabled, iapExperiementEnabled: iapExperiementEnabled, group: group, screen: .courseUnit)
     }
     
     private func trackPriceLoadDuration(elapsedTime: Int) {

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -163,7 +163,7 @@ class ValuePropComponentView: UIView {
             make.leading.equalTo(container).offset(StandardHorizontalMargin)
             make.trailing.equalTo(container).inset(StandardHorizontalMargin)
             make.top.equalTo(infoMessagesView.snp.bottom).offset(StandardVerticalMargin * 3)
-            make.height.equalTo(CourseUpgradeButtonView.height)
+            make.height.equalTo(upgradeButton.height)
         }
     }
     

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -201,7 +201,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
             make.leading.equalTo(view).offset(StandardHorizontalMargin)
             make.trailing.equalTo(view).inset(StandardHorizontalMargin)
             make.bottom.equalTo(safeBottom).inset(StandardVerticalMargin)
-            make.height.equalTo(CourseUpgradeButtonView.height)
+            make.height.equalTo(upgradeButton.height)
         }
     }
     

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -9,28 +9,15 @@
 import UIKit
 
 enum CourseUpgradeScreen: String {
-    case myCourses
-    case courseDashboard
-    case courseUnit
+    case myCourses = "course_enrollment"
+    case courseDashboard = "course_dashboard"
+    case courseUnit = "course_unit"
     case none
-
-    var text: String {
-        switch self {
-        case .myCourses:
-            return "course_enrollment"
-        case .courseDashboard:
-            return "course_dashboard"
-        case .courseUnit:
-            return "course_component"
-        case .none:
-            return "none"
-        }
-    }
 }
 
 class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverriding {
     
-    typealias Environment = OEXAnalyticsProvider & OEXStylesProvider & ReachabilityProvider & NetworkManagerProvider & OEXConfigProvider & OEXInterfaceProvider
+    typealias Environment = OEXAnalyticsProvider & OEXStylesProvider & ReachabilityProvider & NetworkManagerProvider & OEXConfigProvider & OEXInterfaceProvider & ServerConfigProvider
     
     private lazy var valuePropTableView: ValuePropMessagesView = {
         let tableView = ValuePropMessagesView()
@@ -99,6 +86,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         addObserver()
         configureView()
         fetchCoursePrice()
+        trackValuePropMessageViewed()
     }
 
     private func fetchCoursePrice() {
@@ -121,6 +109,14 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
                 }
             }
         }
+    }
+    
+    private func trackValuePropMessageViewed() {
+        guard let courseID = course.course_id else { return }
+        let paymentsEnabled = (environment.serverConfig.iapConfig?.enabled ?? false) && course.sku != nil
+        let iapExperiementEnabled = environment.serverConfig.iapConfig?.experimentEnabled ?? false
+        let group = environment.serverConfig.iapConfig?.experimentGroup
+        environment.analytics.trackValuePropMessageViewed(courseID: courseID, paymentsEnabled: paymentsEnabled, iapExperiementEnabled: iapExperiementEnabled, group: group, screen: screen)
     }
     
     private func trackPriceLoadDuration(elapsedTime: Int) {


### PR DESCRIPTION
### Description

[LEARNER-9031](https://2u-internal.atlassian.net/browse/LEARNER-9031)



### Notes
The config changes are available on the [iapduplicate sandbox](https://iapduplicate.sandbox.edx.org). 


### How to test this PR
`saeed/Fedx1234` and `saeed1/Fedx1234` users can be used to test the PR.

if IAP enabled flag & IAP experiment enabled flag are enabled:

- [ ] every treatment group user should see the purchase button

- [ ] and every control group user shouldn’t see the purchase button and only the value prop experience

if IAP enabled flag is enabled & IAP experiment enabled flag is disabled:

- [ ] then every user should be able to see the purchase button

- [ ] if IAP enabled flag is disabled it wouldn’t matter if IAP experiment enabled flag is enabled or not, no user would be seeing the purchase button.
