### PR TITLE
[feat] logout disabled user

### DIFF
--- a/Source/NSError+JSON.swift
+++ b/Source/NSError+JSON.swift
@@ -35,6 +35,7 @@ enum APIErrorCode: String, CaseIterable {
     case JWTTokenIsBlacklisted = "Token is blacklisted."
     case JWTMustIncludePreferredClaim = "JWT must include a preferred_username or username claim!"
     case JWTUserRetrievalFailed = "User retrieval failed."
+    case JWTUserDisabled = "account_disabled"
     
     var action: APIErrorCodeAction {
         switch self {

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -79,6 +79,18 @@ class NetworkManager_AuthenticationTests : XCTestCase {
         XCTAssertTrue(result.isProceed)
         XCTAssertFalse(router.logoutCalled)
     }
+
+    func testDisabledAccount() {
+        let user = OEXUserDetails.freshUser()
+        let environment = TestRouterEnvironment(user: user)
+        let router = MockRouter(environment: environment)
+        let session = sessionWithRefreshTokenBuilder()
+        let response = simpleResponseBuilder(401)
+        let data = "{\"error_code\":\"account_disabled\"}".data(using: String.Encoding.utf8)!
+        let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: false)
+        XCTAssertTrue(result.isProceed)
+        XCTAssertFalse(router.logoutCalled)
+    }
     
     func testLogoutWithNonJSONData() {
         let router = MockRouter()


### PR DESCRIPTION
### Description

[LEARNER-8967](https://2u-internal.atlassian.net/browse/LEARNER-8967)

Logout disabled user on receiving the response following response in response of `oauth2/login/`

```
URL: https://courses.edx.org/oauth2/login/
status_code: 401
{
  "error_code": "account_disabled",
  "developer_message": "User account is disabled."
}
```

### How to test this PR

- Sign in with a valid user
- Disabled the user from the support tool
- rerun the app and see the response of `/oauth2/login/`
