### PR TITLE
chore: incorporate enrollments v2 changes

### DIFF
--- a/Source/CoursesAPI.swift
+++ b/Source/CoursesAPI.swift
@@ -12,12 +12,12 @@ import edXCore
 struct CoursesAPI {
     private enum Keys: String, RawStringExtractable {
         case enrollments
-        case config
+        case configs
     }
     
     static func enrollmentsDeserializer(response: HTTPURLResponse, json: JSON) -> Result<[UserCourseEnrollment]> {
-        if json[Keys.config].exists() {
-            ServerConfiguration.shared.initialize(json: json[Keys.config])
+        if json[Keys.configs].exists() {
+            ServerConfiguration.shared.initialize(json: json[Keys.configs])
         }
         if json[Keys.enrollments].exists() {
             return (json[Keys.enrollments].array?.compactMap { UserCourseEnrollment(json: $0) }).toResult()

--- a/Source/ServerConfiguration.swift
+++ b/Source/ServerConfiguration.swift
@@ -21,6 +21,7 @@ public extension ServerConfigProvider {
 @objc public class ServerConfiguration: NSObject {
     private enum Keys: String, RawStringExtractable {
         case valuePropEnabled = "value_prop_enabled"
+        case config = "config"
     }
     
     @objc static let shared = ServerConfiguration()
@@ -32,7 +33,11 @@ public extension ServerConfigProvider {
     }
     
     func initialize(json: JSON) {
-        guard let dictionary = json.dictionaryObject else { return }
-        valuePropEnabled = dictionary[Keys.valuePropEnabled] as? Bool ?? false
+        guard let dictionary = json.dictionaryObject,
+              let configString = dictionary[Keys.config] as? String,
+              let configData = configString.data(using: .utf8),
+              let config = try? JSONSerialization.jsonObject(with: configData, options : []) as? Dictionary<String,Any> else { return }
+
+        valuePropEnabled = config[Keys.valuePropEnabled] as? Bool ?? false
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-9071](https://2u-internal.atlassian.net/browse/LEARNER-9071)

Changes are made to the enrollments API to return the value_prop and the IAP  configs. 

###Config PR
https://github.com/edx/edx-mobile-config/pull/130

### Testing
- [ ] Parse the config for enrollments and configs values
- [ ] The enrollments should work the way they are working in V1 of enrollments API
- [ ] The Django admin should control the value prop enable/disalbe 
- [ ] The IAP config will be managed from the Django admin
