### PR TITLE
fix: fix possible network layer crash

### DIFF
--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -90,7 +90,6 @@ private func refreshAccessToken(router: OEXRouter?, clientId: String, refreshTok
         
         networkManager.performTaskForRequest(networkRequest) { [weak networkManager] result in
             var success = false
-            
             if let currentUser = session.currentUser {
                 if let newAccessToken = result.data {
                     success = true
@@ -99,12 +98,21 @@ private func refreshAccessToken(router: OEXRouter?, clientId: String, refreshTok
                 } else {
                     networkManager?.tokenStatus = .expired
                 }
-                networkManager?.performQueuedTasks(success: success)
-            } else {
-                networkManager?.removeAllQueuedTasks()
             }
+            performQueuedTasks(router: router, success: success)
             
             return completion(success)
+        }
+    }
+}
+
+private func performQueuedTasks(router: OEXRouter?, success: Bool) {
+    DispatchQueue.main.async {
+        if success == true {
+            router?.environment.networkManager.performQueuedTasks(success: success)
+        }
+        else {
+            router?.environment.networkManager.removeAllQueuedTasks()
         }
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-9112](https://2u-internal.atlassian.net/browse/LEARNER-9112)

Fixed the crash happening randomly for few learners after the release 3.1.3. The possible reason for the crash is, the static func memory got free after the closure return and the caller wasn't finished its job.

Gave execution to another static func with the main thread so after closure the pending calls should its own memory stack.

### Notes
The crash is not reproducible. We will see after the next release either the crash is fixed or not.
