### PR TITLE
fix: fix removing of unlocking full access banner on course upgrade

### DIFF
--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -230,6 +230,9 @@ extension CourseUpgradeHandler {
                let errorMessage = json.dictionary?.values.first {
                 return "\(type.errorString)-\(error.code)-\(errorMessage)"
             }
+            else if let errorMessage = error.userInfo[NSLocalizedDescriptionKey] as? String {
+                return errorMessage
+            }
 
             return "\(type.errorString)-\(error.code)-\(unhandledError)"
         }

--- a/Source/EnrolledCoursesViewController+CourseUpgrade.swift
+++ b/Source/EnrolledCoursesViewController+CourseUpgrade.swift
@@ -21,7 +21,7 @@ extension EnrolledCoursesViewController {
             else { return }
 
         if courseUpgradeModel.screen == .courseDashboard || courseUpgradeModel.screen == .courseUnit {
-            navigationController?.popToViewController(of: EnrolledTabBarViewController.self, animated: true) { [weak self] in
+            navigationController?.popToViewController(of: EnrolledCoursesViewController.self, animated: true) { [weak self] in
                 guard let weakSelf = self else { return }
                 weakSelf.environment.router?.showCourseWithID(courseID: courseUpgradeModel.courseID, fromController: weakSelf, animated: true)
             }


### PR DESCRIPTION
### Description

[LEARNER-9135](https://2u-internal.atlassian.net/browse/LEARNER-9135)

Fixed the case where the `Unlocking full access to the course` banner was not removing after upgrading the course from dashboard or course component screen.

### Notes
I've also fixed the case where the error message for request time out was not being sent in the email.

