### PR TITLE
fix: disable price load event for control group

### DIFF
--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -179,7 +179,7 @@ class ValuePropComponentView: UIView {
     }
     
     private func fetchCoursePrice() {
-        guard let course = course, let courseSku = course.sku else { return }
+        guard let course = course, let courseSku = course.sku, environment.serverConfig.iapConfig?.enabledforUser == true else { return }
         let startTime = CFAbsoluteTimeGetCurrent()
         
         DispatchQueue.main.async { [weak self] in

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -90,7 +90,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
     }
 
     private func fetchCoursePrice() {
-        guard let courseSku = course.sku else { return }
+        guard let courseSku = course.sku, environment.serverConfig.iapConfig?.enabledforUser == true else { return }
         
         let startTime = CFAbsoluteTimeGetCurrent()
         


### PR DESCRIPTION
### Description

[LEARNER-9132](https://2u-internal.atlassian.net/browse/LEARNER-9132)

Don't send price load analytics when the payment is disabled for the control group.