### PR TITLE
Fix: Access Window object on Main Thread

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -221,7 +221,6 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
     private func syncCookiesStorage() {
         let cookies = HTTPCookieStorage.shared.cookies
         DispatchQueue.global().async { [weak self] in
-            self?.logTestAnalayticsForCrash(name: "TestEvent: syncing cookies")
             let semaphore = DispatchSemaphore(value: 0)
             for cookie in cookies ?? [] {
                 if let webview = self?.webController.view as? WKWebView {
@@ -236,20 +235,8 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
             DispatchQueue.main.async {
                 self?.cookiesManager.updateSessionState(state: .created)
                 self?.reload()
-                self?.logTestAnalayticsForCrash(name: "TestEvent: cookies synced")
             }
         }
-    }
-
-    private func logTestAnalayticsForCrash(name: String) {
-        let event = OEXAnalyticsEvent()
-        event.displayName = name;
-        let info = [
-            "loaded_url": contentRequest?.url?.absoluteString ?? "",
-            "token_status": environment.networkManager.tokenStatus.rawValue
-        ] as [String : Any]
-
-        environment.analytics.trackEvent(event, forComponent: nil, withInfo: info)
     }
 
     private func addAjaxCallbackScript(in contentController: WKUserContentController) {

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -60,18 +60,6 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
         }
     }
 
-    private func logTestAnalayticsForCrash() {
-        let event = OEXAnalyticsEvent()
-        event.displayName = "TestEvent: Loading block URL";
-        let info = [
-            "block_id": blockID ?? "",
-            "course_id": courseID,
-            "token_status": environment.networkManager.tokenStatus.rawValue
-        ] as [String : Any]
-
-        environment.analytics.trackEvent(event, forComponent: nil, withInfo: info)
-    }
-
     private func setupViews() {
         view.addSubview(courseDateBannerView)
         courseDateBannerView.snp.makeConstraints { make in
@@ -133,7 +121,6 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
                 if let url = block.blockURL {
                     let request = NSURLRequest(url: url as URL)
                     self?.webController.loadRequest(request: request)
-                    self?.logTestAnalayticsForCrash()
                 }
                 else {
                     self?.webController.showError(error: nil)

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -82,7 +82,6 @@ private func logout(router: OEXRouter?) -> AuthenticationAction {
  new access token is saved and a successful AuthenticationAction is returned.
  */
 private func refreshAccessToken(router: OEXRouter?, clientId: String, refreshToken: String, session: OEXSession) -> AuthenticationAction {
-    logTestAnalayticsForCrash(router: router, name: "TestEvent: Refreshing Token")
     router?.environment.networkManager.tokenStatus = .authenticating
     
     return .authenticate { networkManager, completion in
@@ -114,16 +113,5 @@ private func performQueuedTasks(router: OEXRouter?, success: Bool) {
         else {
             router?.environment.networkManager.removeAllQueuedTasks()
         }
-        logTestAnalayticsForCrash(router: router, name: "TestEvent: Token Refreshed \(success)")
     }
-}
-
-private func logTestAnalayticsForCrash(router: OEXRouter?, name: String) {
-    let event = OEXAnalyticsEvent()
-    event.displayName = name;
-    let info = [
-        "token_status": router?.environment.networkManager.tokenStatus.rawValue ?? 100
-    ] as [String : Any]
-
-    router?.environment.analytics.trackEvent(event, forComponent: nil, withInfo: info)
 }

--- a/Source/OEXCourseInfoViewController.m
+++ b/Source/OEXCourseInfoViewController.m
@@ -85,16 +85,6 @@ static NSString* const OEXCourseInfoLinkPathIDPlaceholder = @"{path_id}";
     }
     
     [self.environment.analytics trackScreenWithName:OEXAnalyticsScreenCourseInfo];
-    [self logTestAnalayticsForCrash];
-}
-
-- (void) logTestAnalayticsForCrash {
-    OEXAnalyticsEvent *event = [[OEXAnalyticsEvent alloc] init];
-    event.displayName = @"TestEvent: course info";
-
-    NSDictionary *info = @{@"path_id": self.pathID, @"course_url": self.courseInfoURL, @"token_status": [NSNumber numberWithLong:(long)[[OEXRouter sharedRouter].environment.networkManager tokenStatus]]};
-
-    [self.environment.analytics trackEvent:event forComponent:nil withInfo:info];
 }
 
 - (void) loadCourseInfoWith: (NSString *) pathId forceLoad: (BOOL)forceLoad {

--- a/Source/ProgramsDiscoveryViewController.swift
+++ b/Source/ProgramsDiscoveryViewController.swift
@@ -72,18 +72,6 @@ class ProgramsDiscoveryViewController: UIViewController, InterfaceOrientationOve
             environment.analytics.trackScreen(withName: AnalyticsScreenName.ProgramInfo.rawValue)
         }
     }
-
-    private func logTestAnalayticsForCrash(url: String?) {
-        let event = OEXAnalyticsEvent()
-        event.displayName = "TestEvent: program detail";
-        let info = [
-            "path_id": pathId ?? "",
-            "program_url": url ?? "",
-            "token_status": environment.networkManager.tokenStatus.rawValue
-        ] as [String : Any]
-
-        environment.analytics.trackEvent(event, forComponent: nil, withInfo: info)
-    }
     
     func loadProgramDetails(with pathId: String) {
         self.pathId = pathId
@@ -110,8 +98,6 @@ class ProgramsDiscoveryViewController: UIViewController, InterfaceOrientationOve
         webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, searchQuery: searchQuery)
         webviewHelper?.baseURL = searchBaseURL
         webviewHelper?.load(withURL: url)
-
-        logTestAnalayticsForCrash(url: url.absoluteString)
     }
     
 }

--- a/Source/UIApplication+UIViewController.swift
+++ b/Source/UIApplication+UIViewController.swift
@@ -11,16 +11,38 @@ import UIKit
 extension UIApplication {
     
     @objc var window: UIWindow? {
-        return UIApplication
-            .shared
-            .connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow }
+        if Thread.isMainThread {
+            return UIApplication
+                .shared
+                .connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }
+        } else {
+            var win: UIWindow?
+            DispatchQueue.main.sync {
+                win = UIApplication
+                    .shared
+                    .connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .flatMap { $0.windows }
+                    .first { $0.isKeyWindow }
+            }
+            
+            return win
+        }
     }
-    
+         
     var interfaceOrientation: UIInterfaceOrientation {
-        return window?.windowScene?.interfaceOrientation ?? .portrait
+        if Thread.isMainThread {
+            return window?.windowScene?.interfaceOrientation ?? .portrait
+        } else {
+            var orientation: UIInterfaceOrientation?
+            DispatchQueue.main.sync {
+                orientation = window?.windowScene?.interfaceOrientation ?? .portrait
+            }
+            return orientation ?? .portrait
+        }
     }
 
     @objc func topMostController() -> UIViewController?  {


### PR DESCRIPTION
### Description

[LEARNER-9143](https://2u-internal.atlassian.net/browse/LEARNER-9143)

Xcode was giving warnings, and was also crashing with non fatals while accessing Application window and interface orientation on background thread. This PR added the capability to access the window and interface orientation on main thread.

This PR also removed the test logs added to figure out the  possible reason on crash. The logs were not helpful much, so removing the test logs.
