### PR TITLE
feat: Add support for external_link parameter in discover webview

### DIFF
--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -199,7 +199,12 @@ extension DiscoveryWebViewHelper: WKNavigationDelegate {
         } else {
             let capturedLink = navigationAction.navigationType == .linkActivated
             let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
-            if let url = request.url, outsideLink || capturedLink {
+            var externalLink = false
+            if let queryParameters = request.url?.queryParameters, let externalLinkValue =  queryParameters["external_link"] as? String, externalLinkValue.caseInsensitiveCompare("true") == .orderedSame {
+                externalLink = true
+            }
+            
+            if let url = request.url, outsideLink || capturedLink || externalLink {
                 guard let contrller = delegate?.webViewContainingController(), UIApplication.shared.canOpenURL(url) else {
                     decisionHandler(.cancel)
                     return

--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -200,7 +200,7 @@ extension DiscoveryWebViewHelper: WKNavigationDelegate {
             let capturedLink = navigationAction.navigationType == .linkActivated
             let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
             var externalLink = false
-            if let queryParameters = request.url?.queryParameters, let externalLinkValue =  queryParameters["external_link"] as? String, externalLinkValue.caseInsensitiveCompare("true") == .orderedSame {
+            if let queryParameters = request.url?.queryParameters, let externalLinkValue = queryParameters["external_link"] as? String, externalLinkValue.caseInsensitiveCompare("true") == .orderedSame {
                 externalLink = true
             }
             


### PR DESCRIPTION


### Description

[LEARNER-9245](https://2u-internal.atlassian.net/browse/LEARNER-9245)


### How to test this PR

The external_link parameter is added on the cards of Simmons University under the Bachelors. But it requires a location of USA. A VPN can be used to simulate the location of USA.
 
<img width="1242" alt="Screenshot 2023-03-06 at 1 45 35 PM" src="https://user-images.githubusercontent.com/5606473/223061347-1c565df8-bb0f-4a3b-8e3b-3f4d9ad73da2.png">

