### PR TITLE
fix: send push notification with sound and alert

### DIFF
--- a/Source/OEXPushNotificationManager.m
+++ b/Source/OEXPushNotificationManager.m
@@ -49,8 +49,8 @@
 - (void)performRegistration {
     UIApplication* application = [UIApplication sharedApplication];
 
-    UNAuthorizationOptions authOptions = UNAuthorizationOptionAlert |
-    UNAuthorizationOptionSound | UNAuthorizationOptionBadge | UNAuthorizationOptionProvisional;
+    UNAuthorizationOptions authOptions = UNAuthorizationOptionSound | UNAuthorizationOptionAlert
+     | UNAuthorizationOptionBadge;
     [UNUserNotificationCenter currentNotificationCenter].delegate = self;
     [[UNUserNotificationCenter currentNotificationCenter]
      requestAuthorizationWithOptions:authOptions


### PR DESCRIPTION
### Description

[LEARNER-9324](https://2u-internal.atlassian.net/browse/LEARNER-9324)

The push notification was delivered silently because of [provisional](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions/2993019-provisional) value of  [UNAuthorizationOptions](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions). I've removed `provisional` from the push notifications settings. Now the push is being received with alert and sound.
