### PR TITLE
feat: show shift dates banner on new course dashboard

### DIFF
--- a/Source/CourseDashboardHeaderView.swift
+++ b/Source/CourseDashboardHeaderView.swift
@@ -34,7 +34,7 @@ class CourseDashboardHeaderView: UIView {
     private lazy var containerView = UIView()
     private lazy var courseInfoContainerView = UIView()
     private var bottomContainer = UIView()
-    lazy private var datesBannerView = NewCourseDateBannerView()
+    private lazy var datesBannerView = NewCourseDateBannerView()
     private var bannerInfo: DatesBannerInfo? = nil
     
     private lazy var orgLabel: UILabel = {
@@ -179,7 +179,7 @@ class CourseDashboardHeaderView: UIView {
     private let course: OEXCourse?
     private let tabbarItems: [TabBarItem]
     private let error: CourseAccessHelper?
-    // it will be used to hide value prop from header in favor of embeded value prop ob course dashboard
+    // it will be used to hide value prop from header in favor of embeded value prop on course dashboard
     private var hideValueProp: Bool = false
     
     init(environment: Environment, course: OEXCourse?, tabbarItems: [TabBarItem], error: CourseAccessHelper?) {

--- a/Source/CourseDashboardHeaderView.swift
+++ b/Source/CourseDashboardHeaderView.swift
@@ -34,6 +34,8 @@ class CourseDashboardHeaderView: UIView {
     private lazy var containerView = UIView()
     private lazy var courseInfoContainerView = UIView()
     private var bottomContainer = UIView()
+    lazy private var datesBannerView = NewCourseDateBannerView()
+    private var bannerInfo: DatesBannerInfo? = nil
     
     private lazy var orgLabel: UILabel = {
         let label = UILabel()
@@ -186,7 +188,7 @@ class CourseDashboardHeaderView: UIView {
         super.init(frame: .zero)
         
         addSubViews()
-        addConstraints()
+        setConstraints()
         configureView()
     }
     
@@ -222,7 +224,7 @@ class CourseDashboardHeaderView: UIView {
         addCertificateView()
     }
     
-    private func addConstraints() {
+    private func setConstraints() {
         containerView.snp.remakeConstraints { make in
             make.edges.equalTo(self)
         }
@@ -292,9 +294,21 @@ class CourseDashboardHeaderView: UIView {
             
             bottomContainer = valuePropView
         }
+        
+        if bannerInfo != nil {
+            datesBannerView.removeFromSuperview()
+            containerView.addSubview(datesBannerView)
+            
+            datesBannerView.snp.remakeConstraints { make in
+                make.top.equalTo(bottomContainer.snp.bottom).offset(StandardVerticalMargin)
+                make.leading.equalTo(containerView)
+                make.trailing.equalTo(containerView)
+            }
+            bottomContainer = datesBannerView
+        }
                 
         tabbarView.snp.remakeConstraints { make in
-            let offSet = bottomContainer == certificateView ? 0 : StandardVerticalMargin * 2
+            let offSet = bottomContainer == certificateView || bannerInfo != nil ? 0 : StandardVerticalMargin * 2
             make.top.equalTo(bottomContainer.snp.bottom).offset(offSet)
             make.leading.equalTo(containerView)
             make.trailing.equalTo(containerView)
@@ -313,13 +327,14 @@ class CourseDashboardHeaderView: UIView {
     
     func showTabbarView(show: Bool) {
         showTabbar = show
-        addConstraints()
+        setConstraints()
     }
     
     func updateHeader(collapse: Bool) {
         courseInfoContainerView.alpha = collapse ? 0 : 1
         valuePropView.alpha = collapse ? 0 : (canShowValuePropView ? 1 : 0)
         certificateView?.alpha = collapse ? 0 : 1
+        datesBannerView.alpha = collapse ? 0 : 1
         updateTabbarConstraints(collapse: collapse)
     }
     
@@ -329,7 +344,7 @@ class CourseDashboardHeaderView: UIView {
     
     func updateTabbarConstraints(collapse: Bool) {
         tabbarView.snp.remakeConstraints { make in
-            let offSet = bottomContainer == certificateView && !collapse ? 0 : StandardVerticalMargin * 2
+            let offSet = bottomContainer == certificateView || bannerInfo != nil && !collapse ? 0 : StandardVerticalMargin * 2
             make.top.equalTo(collapse ? closeButton.snp.bottom : bottomContainer.snp.bottom).offset(offSet)
             make.leading.equalTo(containerView)
             make.trailing.equalTo(containerView)
@@ -338,6 +353,22 @@ class CourseDashboardHeaderView: UIView {
                 make.bottom.equalTo(containerView)
             }
         }
+    }
+    
+    func showDatesBanner(delegate: CourseOutlineTableController?, bannerInfo: DatesBannerInfo?) {
+        self.bannerInfo = bannerInfo
+        datesBannerView.bannerInfo = bannerInfo
+        datesBannerView.delegate = delegate
+        datesBannerView.setupView()
+        setConstraints()
+    }
+    
+    func removeDatesBanner() {
+        bannerInfo = nil
+        datesBannerView.bannerInfo = bannerInfo
+        datesBannerView.delegate = nil
+        datesBannerView.removeFromSuperview()
+        setConstraints()
     }
 }
 

--- a/Source/CourseDashboardHeaderView.swift
+++ b/Source/CourseDashboardHeaderView.swift
@@ -179,6 +179,8 @@ class CourseDashboardHeaderView: UIView {
     private let course: OEXCourse?
     private let tabbarItems: [TabBarItem]
     private let error: CourseAccessHelper?
+    // it will be used to hide value prop from header in favor of embeded value prop ob course dashboard
+    private var hideValueProp: Bool = false
     
     init(environment: Environment, course: OEXCourse?, tabbarItems: [TabBarItem], error: CourseAccessHelper?) {
         self.environment = environment
@@ -188,7 +190,7 @@ class CourseDashboardHeaderView: UIView {
         super.init(frame: .zero)
         
         addSubViews()
-        setConstraints()
+        setOrUpdateConstraints()
         configureView()
     }
     
@@ -224,7 +226,7 @@ class CourseDashboardHeaderView: UIView {
         addCertificateView()
     }
     
-    private func setConstraints() {
+    private func setOrUpdateConstraints() {
         containerView.snp.remakeConstraints { make in
             make.edges.equalTo(self)
         }
@@ -282,7 +284,7 @@ class CourseDashboardHeaderView: UIView {
             bottomContainer = certificateView
         }
         
-        if canShowValuePropView {
+        if canShowValuePropView && !hideValueProp {
             containerView.addSubview(valuePropView)
             
             valuePropView.snp.remakeConstraints { make in
@@ -293,6 +295,12 @@ class CourseDashboardHeaderView: UIView {
             }
             
             bottomContainer = valuePropView
+        }
+        else {
+            valuePropView.snp.remakeConstraints { make in
+                make.height.equalTo(0)
+            }
+            valuePropView.removeFromSuperview()
         }
         
         if bannerInfo != nil {
@@ -327,12 +335,12 @@ class CourseDashboardHeaderView: UIView {
     
     func showTabbarView(show: Bool) {
         showTabbar = show
-        setConstraints()
+        setOrUpdateConstraints()
     }
     
     func updateHeader(collapse: Bool) {
         courseInfoContainerView.alpha = collapse ? 0 : 1
-        valuePropView.alpha = collapse ? 0 : (canShowValuePropView ? 1 : 0)
+        valuePropView.alpha = collapse ? 0 : (canShowValuePropView && !hideValueProp ? 1 : 0)
         certificateView?.alpha = collapse ? 0 : 1
         datesBannerView.alpha = collapse ? 0 : 1
         updateTabbarConstraints(collapse: collapse)
@@ -360,7 +368,7 @@ class CourseDashboardHeaderView: UIView {
         datesBannerView.bannerInfo = bannerInfo
         datesBannerView.delegate = delegate
         datesBannerView.setupView()
-        setConstraints()
+        setOrUpdateConstraints()
     }
     
     func removeDatesBanner() {
@@ -368,7 +376,12 @@ class CourseDashboardHeaderView: UIView {
         datesBannerView.bannerInfo = bannerInfo
         datesBannerView.delegate = nil
         datesBannerView.removeFromSuperview()
-        setConstraints()
+        setOrUpdateConstraints()
+    }
+    
+    func hidevalueProp(hide: Bool = true) {
+        hideValueProp = hide
+        setOrUpdateConstraints()
     }
 }
 

--- a/Source/CourseDates.swift
+++ b/Source/CourseDates.swift
@@ -221,7 +221,7 @@ enum BannerInfoStatus {
     }
 }
 
-class DatesBannerInfo {
+public class DatesBannerInfo {
     private enum Keys: String, RawStringExtractable {
         case contentTypeGatingEnabled = "content_type_gating_enabled"
         case missedDeadline = "missed_deadlines"

--- a/Source/CourseDatesHeaderView.swift
+++ b/Source/CourseDatesHeaderView.swift
@@ -133,7 +133,7 @@ class CourseDatesHeaderView: UITableViewHeaderFooterView {
             setupBottomContainer()
         }
         
-        if !isSelfPaced && bannerInfo.status != .upgradeToCompleteGradedBanner {
+        if (!isSelfPaced && bannerInfo.status != .upgradeToCompleteGradedBanner) || bannerInfo.status == .resetDatesBanner {
             topContainer.subviews.forEach { $0.removeFromSuperview() }
         }
         

--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -22,11 +22,12 @@ protocol CourseOutlineTableControllerDelegate: AnyObject {
     func resetCourseDate(controller: CourseOutlineTableController)
 }
 
-class CourseOutlineTableController: UITableViewController, ScrollableDelegateProvider {
+public class CourseOutlineTableController: UITableViewController, ScrollableDelegateProvider {
 
     typealias Environment = DataManagerProvider & OEXInterfaceProvider & NetworkManagerProvider & OEXConfigProvider & OEXRouterProvider & OEXAnalyticsProvider & OEXStylesProvider & ServerConfigProvider
     
     weak var delegate: CourseOutlineTableControllerDelegate?
+    weak var newDashboardDelegate: NewCourseDashboardViewControllerDelegate?
     
     private let environment: Environment
     private let courseID: String
@@ -49,7 +50,7 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
     private var isResumeCourse = false
     private var shouldHideTableViewHeader: Bool = false
     
-    weak var scrollableDelegate: ScrollableDelegate?
+    weak public var scrollableDelegate: ScrollableDelegate?
     private var scrollByDragging = false
         
     private var collapsedSections = Set<Int>()
@@ -116,7 +117,7 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
         valuePropView.accessibilityIdentifier = "CourseOutlineTableController:value-prop-view"
     }
     
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
@@ -208,7 +209,7 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
         }
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         if let path = tableView.indexPathForSelectedRow {
@@ -223,11 +224,11 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
         courseOutlineMode == .video ? courseVideosHeaderView?.refreshView() : nil
     }
     
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         tableView.reloadData()
     }
     
-    override func updateViewConstraints() {
+    public override func updateViewConstraints() {
         super.updateViewConstraints()
         refreshTableHeaderView(isResumeCourse: isResumeCourse)
     }
@@ -237,21 +238,21 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
     }
     
     // MARK: UITableView DataSource & Delegate
-    override func numberOfSections(in tableView: UITableView) -> Int {
+    public override func numberOfSections(in tableView: UITableView) -> Int {
         return groups.count
     }
     
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    public override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return shouldApplyNewStyle(groups[section])
             ? collapsedSections.contains(section) ? 0 : groups[section].children.count
             : groups[section].children.count
     }
     
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    public override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return shouldApplyNewStyle(groups[section]) ? StandardVerticalMargin * 7.5 : StandardVerticalMargin * 3.75
     }
     
-    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: CourseOutlineHeaderCell.identifier) as! CourseOutlineHeaderCell
         
         let group = groups[section]
@@ -272,23 +273,23 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
         return header
     }
     
-    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    public override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return shouldApplyNewStyle(groups[section]) ? StandardVerticalMargin * 2 : 0
     }
     
-    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         return shouldApplyNewStyle(groups[section]) ? UIView() : nil
     }
     
-    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+    public override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         return 60
     }
     
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    public override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
     }
     
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    public override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let group = groups[indexPath.section]
         let nodes = group.children
         let block = nodes[indexPath.row]
@@ -351,7 +352,7 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
         }
     }
     
-    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    public override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         guard let cell = cell as? CourseBlockContainerCell else {
             assertionFailure("All course outline cells should implement CourseBlockContainerCell")
             return
@@ -361,13 +362,13 @@ class CourseOutlineTableController: UITableViewController, ScrollableDelegatePro
         cell.applyStyle(style: highlighted ? .Highlighted : .Normal)
     }
     
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let group = groups[indexPath.section]
         let chosenBlock = group.children[indexPath.row]
         delegate?.outlineTableController(controller: self, choseBlock: chosenBlock, parent: group.block.blockID)
     }
     
-    override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+    public override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         guard let cell = tableView.cellForRow(at: indexPath) as? SwipeableCell, cell.state != .initial  else {
             return indexPath
         }
@@ -534,7 +535,12 @@ extension CourseOutlineTableController {
     }
     
     func showCourseDateBanner(bannerInfo: DatesBannerInfo) {
-        if environment.config.isNewDashboardEnabled { return }
+        if environment.config.isNewDashboardEnabled {
+            if bannerInfo.status == .resetDatesBanner {
+                showCourseDates(bannerInfo: bannerInfo, delegate: self)
+            }
+            return
+        }
        
         if canShowValueProp && bannerInfo.status == .resetDatesBanner {
             courseDateBannerView.bannerInfo = bannerInfo
@@ -547,7 +553,10 @@ extension CourseOutlineTableController {
     }
     
     func hideCourseDateBanner() {
-        if environment.config.isNewDashboardEnabled { return }
+        if environment.config.isNewDashboardEnabled {
+            hideCourseDates()
+            return
+        }
         courseDateBannerView.bannerInfo = nil
         updateCourseDateBannerView(show: false)
     }
@@ -759,17 +768,17 @@ extension CourseOutlineTableController: BlockCompletionDelegate {
 }
 
 extension CourseOutlineTableController {
-    override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+    public override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         scrollByDragging = true
     }
     
-    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    public override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollByDragging {
             scrollableDelegate?.scrollViewDidScroll(scrollView: scrollView)
         }
     }
     
-    override func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+    public override func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         scrollByDragging = false
     }
 }
@@ -780,6 +789,16 @@ extension CourseOutlineTableController: CourseOutlineHeaderCellDelegate {
             collapsedSections = collapsedSections.symmetricDifference([section])
             tableView.reloadSections([section], with: .none)
         }
+    }
+}
+
+extension CourseOutlineTableController: NewCourseDashboardViewControllerDelegate {
+    public func showCourseDates(bannerInfo: DatesBannerInfo?, delegate: CourseOutlineTableController?) {
+        newDashboardDelegate?.showCourseDates(bannerInfo: bannerInfo, delegate: self)
+    }
+    
+    public func hideCourseDates() {
+        newDashboardDelegate?.hideCourseDates()
     }
 }
 

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -43,6 +43,7 @@ public class CourseOutlineViewController :
     private(set) var courseOutlineMode: CourseOutlineMode
     private var loadCachedResponse: Bool = true
     private lazy var courseUpgradeHelper = CourseUpgradeHelper.shared
+    weak var newDashboardDelegate: NewCourseDashboardViewControllerDelegate?
     
     /// Strictly a test variable used as a trigger flag. Not to be used out of the test scope
     fileprivate var t_hasTriggeredSetResumeCourse = false
@@ -85,7 +86,7 @@ public class CourseOutlineViewController :
         tableController = CourseOutlineTableController(environment: environment, courseID: courseID, forMode: courseOutlineMode, courseBlockID: rootID)
         tableController.newDashboardDelegate = newDashboardDelegate
         resumeCourseController = ResumeCourseController(blockID: rootID , dataManager: environment.dataManager, networkManager: environment.networkManager, courseQuerier: courseQuerier, forMode: courseOutlineMode)
-        
+        self.newDashboardDelegate = newDashboardDelegate
         super.init(env: environment, shouldShowOfflineSnackBar: false)
         
         addObservers()
@@ -405,7 +406,13 @@ public class CourseOutlineViewController :
     }
     
     private func showSnackBar() {
-        showDateResetSnackBar(message: Strings.Coursedates.toastSuccessMessage, buttonText: Strings.Coursedates.viewAllDates, showButton: true) { [weak self] in
+        guard let topController = UIApplication.shared.topMostController() else { return }
+        var showViewDatesButton = true
+        if let selectedController = newDashboardDelegate?.selectedController() {
+            showViewDatesButton = !(selectedController is CourseDatesViewController)
+        }
+        
+        topController.showDateResetSnackBar(message: Strings.Coursedates.toastSuccessMessage, buttonText: Strings.Coursedates.viewAllDates, showButton: showViewDatesButton) { [weak self] in
             if let weakSelf = self {
                 weakSelf.environment.router?.showDatesTabController(controller: weakSelf)
                 weakSelf.hideSnackBar()

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -74,7 +74,7 @@ public class CourseOutlineViewController :
         }
     }
     
-    public init(environment: Environment, courseID : String, rootID : CourseBlockID?, forMode mode: CourseOutlineMode?) {
+    public init(environment: Environment, courseID : String, rootID : CourseBlockID?, forMode mode: CourseOutlineMode?, newDashboardDelegate: NewCourseDashboardViewControllerDelegate? = nil) {
         self.rootID = rootID
         self.environment = environment
         courseQuerier = environment.dataManager.courseDataManager.querierForCourseWithID(courseID: courseID, environment: environment)
@@ -83,6 +83,7 @@ public class CourseOutlineViewController :
         insetsController = ContentInsetsController()
         courseOutlineMode = mode ?? .full
         tableController = CourseOutlineTableController(environment: environment, courseID: courseID, forMode: courseOutlineMode, courseBlockID: rootID)
+        tableController.newDashboardDelegate = newDashboardDelegate
         resumeCourseController = ResumeCourseController(blockID: rootID , dataManager: environment.dataManager, networkManager: environment.networkManager, courseQuerier: courseQuerier, forMode: courseOutlineMode)
         
         super.init(env: environment, shouldShowOfflineSnackBar: false)

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -78,6 +78,7 @@ public class CourseOutlineViewController :
     public init(environment: Environment, courseID : String, rootID : CourseBlockID?, forMode mode: CourseOutlineMode?, newDashboardDelegate: NewCourseDashboardViewControllerDelegate? = nil) {
         self.rootID = rootID
         self.environment = environment
+        self.newDashboardDelegate = newDashboardDelegate
         courseQuerier = environment.dataManager.courseDataManager.querierForCourseWithID(courseID: courseID, environment: environment)
         
         loadController = LoadStateViewController()
@@ -86,7 +87,7 @@ public class CourseOutlineViewController :
         tableController = CourseOutlineTableController(environment: environment, courseID: courseID, forMode: courseOutlineMode, courseBlockID: rootID)
         tableController.newDashboardDelegate = newDashboardDelegate
         resumeCourseController = ResumeCourseController(blockID: rootID , dataManager: environment.dataManager, networkManager: environment.networkManager, courseQuerier: courseQuerier, forMode: courseOutlineMode)
-        self.newDashboardDelegate = newDashboardDelegate
+        
         super.init(env: environment, shouldShowOfflineSnackBar: false)
         
         addObservers()

--- a/Source/NewCourseDashboardViewController.swift
+++ b/Source/NewCourseDashboardViewController.swift
@@ -11,6 +11,13 @@ import UIKit
 public protocol NewCourseDashboardViewControllerDelegate: AnyObject {
     func showCourseDates(bannerInfo: DatesBannerInfo?, delegate: CourseOutlineTableController?)
     func hideCourseDates()
+    func selectedController() -> UIViewController?
+}
+
+extension NewCourseDashboardViewControllerDelegate {
+    public func selectedController() -> UIViewController? {
+        return nil
+    }
 }
 
 class NewCourseDashboardViewController: UIViewController, InterfaceOrientationOverriding {
@@ -562,6 +569,10 @@ extension NewCourseDashboardViewController: NewCourseDashboardViewControllerDele
     
     func hideCourseDates() {
         headerView.removeDatesBanner()
+    }
+    
+    func selectedController() -> UIViewController? {
+        return selectedTabbarItem?.viewController
     }
 }
 

--- a/Source/NewCourseDashboardViewController.swift
+++ b/Source/NewCourseDashboardViewController.swift
@@ -8,6 +8,11 @@
 
 import UIKit
 
+public protocol NewCourseDashboardViewControllerDelegate: AnyObject {
+    func showCourseDates(bannerInfo: DatesBannerInfo?, delegate: CourseOutlineTableController?)
+    func hideCourseDates()
+}
+
 class NewCourseDashboardViewController: UIViewController, InterfaceOrientationOverriding {
     
     typealias Environment = OEXAnalyticsProvider & OEXConfigProvider & DataManagerProvider & NetworkManagerProvider & OEXRouterProvider & OEXInterfaceProvider & ReachabilityProvider & OEXSessionProvider & OEXStylesProvider & RemoteConfigProvider & ServerConfigProvider
@@ -120,7 +125,7 @@ class NewCourseDashboardViewController: UIViewController, InterfaceOrientationOv
             make.top.equalTo(contentView)
             make.leading.equalTo(contentView)
             make.trailing.equalTo(contentView)
-            make.height.lessThanOrEqualTo(StandardVerticalMargin * 60)
+            make.height.lessThanOrEqualTo(StandardVerticalMargin * 100)
         }
         
         container.snp.remakeConstraints { make in
@@ -243,8 +248,8 @@ class NewCourseDashboardViewController: UIViewController, InterfaceOrientationOv
     
     private func prepareTabViewData() {
         tabBarItems = []
-        
-        var item = TabBarItem(title: Strings.Dashboard.courseHome, viewController: CourseOutlineViewController(environment: environment, courseID: courseID, rootID: nil, forMode: .full), icon: Icon.Courseware, detailText: Strings.Dashboard.courseCourseDetail)
+        let outlineController = CourseOutlineViewController(environment: environment, courseID: courseID, rootID: nil, forMode: .full, newDashboardDelegate: self)
+        var item = TabBarItem(title: Strings.Dashboard.courseHome, viewController: outlineController, icon: Icon.Courseware, detailText: Strings.Dashboard.courseCourseDetail)
         tabBarItems.append(item)
         
         if environment.config.isCourseVideosEnabled {
@@ -547,6 +552,16 @@ extension NewCourseDashboardViewController {
         } completion: { [weak self] _ in
             self?.headerViewState = .collapsed
         }
+    }
+}
+
+extension NewCourseDashboardViewController: NewCourseDashboardViewControllerDelegate {
+    func showCourseDates(bannerInfo: DatesBannerInfo?, delegate: CourseOutlineTableController?) {
+        headerView.showDatesBanner(delegate: delegate, bannerInfo: bannerInfo)
+    }
+    
+    func hideCourseDates() {
+        headerView.removeDatesBanner()
     }
 }
 

--- a/Source/NewCourseDashboardViewController.swift
+++ b/Source/NewCourseDashboardViewController.swift
@@ -191,6 +191,7 @@ class NewCourseDashboardViewController: UIViewController, InterfaceOrientationOv
         container.subviews.forEach { $0.removeFromSuperview() }
         
         if showCourseAccessError {
+            headerView.hidevalueProp()
             let view = CourseDashboardAccessErrorView()
             view.delegate = self
             view.handleCourseAccessError(environment: environment, course: course, error: courseAccessHelper)
@@ -199,6 +200,7 @@ class NewCourseDashboardViewController: UIViewController, InterfaceOrientationOv
                 make.edges.equalTo(container)
             }
         } else if showContentNotLoadedError {
+            headerView.hidevalueProp()
             let view = CourseDashboardErrorView()
             view.myCoursesAction = { [weak self] in
                 self?.dismiss(animated: true)
@@ -208,6 +210,7 @@ class NewCourseDashboardViewController: UIViewController, InterfaceOrientationOv
                 make.edges.equalTo(container)
             }
         } else if let tabBarItem = selectedTabbarItem {
+            headerView.hidevalueProp(hide: false)
             let contentController = tabBarItem.viewController
             if var controller = contentController as? ScrollableDelegateProvider {
                 controller.scrollableDelegate = self

--- a/Source/NewCourseDateBannerView.swift
+++ b/Source/NewCourseDateBannerView.swift
@@ -1,0 +1,140 @@
+//
+//  NewCourseDateBannerView.swift
+//  edX
+//
+//  Created by SaeedBashir on 4/12/23.
+//  Copyright © 2023 edX. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+private let cornerRadius: CGFloat = 0
+
+class NewCourseDateBannerView: UIView {
+    private var buttonHeight: CGFloat = 32
+    private lazy var container = UIView()
+    
+    private lazy var messageLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.numberOfLines = 0
+        label.accessibilityIdentifier = "NewCourseDateBannerView:message-label"
+        return label
+    }()
+    
+    private lazy var bannerHeaderStyle: OEXMutableTextStyle = {
+        let style = OEXMutableTextStyle(weight: .bold, size: .small, color: OEXStyles.shared().neutralXXDark())
+        style.lineBreakMode = .byWordWrapping
+        return style
+    }()
+    
+    private lazy var bannerBodyStyle: OEXMutableTextStyle = {
+        let style = OEXMutableTextStyle(weight: .normal, size: .small, color: OEXStyles.shared().neutralXXDark())
+        style.lineBreakMode = .byWordWrapping
+        return style
+    }()
+    
+    private lazy var buttonStyle: OEXMutableTextStyle = {
+        return OEXMutableTextStyle(weight: .semiBold, size: .base, color: OEXStyles.shared().neutralWhiteT())
+    }()
+    
+    private lazy var bannerButton: UIButton = {
+        let button = UIButton()
+        button.contentEdgeInsets = UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 15)
+        button.layer.backgroundColor = OEXStyles.shared().primaryBaseColor().cgColor
+        button.layer.borderColor = OEXStyles.shared().primaryBaseColor().cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = cornerRadius
+        button.oex_removeAllActions()
+        button.oex_addAction({ [weak self] _ in
+            self?.bannerButtonAction()
+            }, for: .touchUpInside)
+        button.accessibilityIdentifier = "NewCourseDateBannerView:reset-date-button"
+        return button
+    }()
+    
+    private var isButtonTextAvailable: Bool {
+        guard let bannerInfo = bannerInfo, let status = bannerInfo.status else { return false }
+        return !status.button.isEmpty
+    }
+    
+    var bannerInfo: DatesBannerInfo?
+    weak var delegate: CourseShiftDatesDelegate?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func setupView() {
+        configureViews()
+        setConstraints()
+        populate()
+    }
+    
+    private func configureViews() {
+        container.subviews.forEach { $0.removeFromSuperview() }
+        container.superview?.removeFromSuperview()
+        backgroundColor = OEXStyles.shared().warningXXLight()
+        addSubview(container)
+        container.addSubview(messageLabel)
+        container.accessibilityIdentifier = "CourseResetDateBannerView:container-view"
+        
+        if isButtonTextAvailable {
+            container.addSubview(bannerButton)
+        }
+    }
+    
+    private func setConstraints() {
+        container.snp.makeConstraints { make in
+            make.edges.equalTo(self)
+        }
+        
+        messageLabel.snp.makeConstraints { make in
+            make.top.equalTo(container).offset(StandardVerticalMargin)
+            make.leading.equalTo(container).offset(StandardHorizontalMargin)
+            make.trailing.equalTo(container).inset(StandardHorizontalMargin)
+        }
+        
+        if isButtonTextAvailable {
+            bannerButton.snp.makeConstraints { make in
+                make.top.equalTo(messageLabel.snp.bottom).offset(StandardVerticalMargin * 2)
+                make.bottom.equalTo(container).inset(StandardVerticalMargin * 2)
+                make.height.equalTo(buttonHeight)
+                make.leading.equalTo(container).offset(StandardHorizontalMargin)
+                make.trailing.equalTo(container).inset(StandardHorizontalMargin)
+            }
+        }
+    }
+    
+    private func populate() {
+        guard let bannerInfo = bannerInfo, let status = bannerInfo.status else { return }
+        
+        let headerText = bannerHeaderStyle.attributedString(withText: status.header)
+        let bodyText = bannerBodyStyle.attributedString(withText: status.body).setLineSpacing(3)
+        
+        let messageText = [headerText, bodyText]
+        let attributedString = NSAttributedString.joinInNaturalLayout(attributedStrings: messageText)
+        
+        messageLabel.attributedText = attributedString
+        messageLabel.sizeToFit()
+        messageLabel.layoutIfNeeded()
+        messageLabel.setNeedsLayout()
+        
+        if isButtonTextAvailable {
+            let buttonText = buttonStyle.attributedString(withText: status.button)
+            bannerButton.setAttributedTitle(buttonText, for: .normal)
+        }
+    }
+    
+    @objc private func bannerButtonAction() {
+        guard let bannerInfo = bannerInfo else { return }
+                
+        if bannerInfo.status == .resetDatesBanner {
+            delegate?.courseShiftDateButtonAction()
+        }
+    }
+}

--- a/Source/NewCourseDateBannerView.swift
+++ b/Source/NewCourseDateBannerView.swift
@@ -9,8 +9,6 @@
 import Foundation
 import UIKit
 
-private let cornerRadius: CGFloat = 0
-
 class NewCourseDateBannerView: UIView {
     private var buttonHeight: CGFloat = 32
     private lazy var container = UIView()
@@ -44,7 +42,7 @@ class NewCourseDateBannerView: UIView {
         button.layer.backgroundColor = OEXStyles.shared().primaryBaseColor().cgColor
         button.layer.borderColor = OEXStyles.shared().primaryBaseColor().cgColor
         button.layer.borderWidth = 1
-        button.layer.cornerRadius = cornerRadius
+        button.layer.cornerRadius = 0
         button.oex_removeAllActions()
         button.oex_addAction({ [weak self] _ in
             self?.bannerButtonAction()

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -198,8 +198,12 @@ extension OEXRouter {
     
     func showDatesTabController(controller: UIViewController) {
         if environment.config.isNewDashboardEnabled {
-            guard let dashboardController = controller.navigationController?.viewControllers.first as? NewCourseDashboardViewController else { return }
-            popToRoot(controller: dashboardController) {
+            if let dashboardController = controller.navigationController?.viewControllers.first as? NewCourseDashboardViewController {
+                popToRoot(controller: dashboardController) {
+                    dashboardController.switchTab(with: .courseDates)
+                }
+            }
+            else if let dashboardController = UIApplication.shared.topMostController() as? NewCourseDashboardViewController {
                 dashboardController.switchTab(with: .courseDates)
             }
         } else {

--- a/Source/ar.lproj/Localizable-2.strings
+++ b/Source/ar.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for Discover*/
 "DISCOVER"="Discover";
 /*Title for Discovery*/

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -336,10 +336,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="مما يعني انك غير قادر ان تشارك في الواجبات المقدرة. يبدو انك فاتتك بعض المواعيد المهمة بناء على جدولنا .لتكمل الواجبات المقدرة كجزء من هذه الدورة ونقل واجبات الماضي الي المستقبل، يمكنك الترقية اليوم";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"=" يبدو انك فاتتك بعض المراعيد المهمة بناء على جدولنا المقترح";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="لتبقى نفسك على المسار الصحيح، يمكنك ترقية جدولك و نقل واجبات الماضي الي المستقبل. لا تقلق لن تخسر اي تقدم فعلته عندما تنقل التواريخ المحددة";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="تغيير المواعيد المقررة";
 /* Course Dates Title */

--- a/Source/de.lproj/Localizable-2.strings
+++ b/Source/de.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for Discover*/
 "DISCOVER"="Discover";
 /*Title for Discovery*/

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -320,10 +320,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="was bedeutet, dass Sie nicht an benoteten Aufgaben teilnehmen können. Es sieht so aus, als ob Sie einige wichtige Fristen verpasst haben, basierend auf unserem vorgeschlagenen Zeitplan. Um benotete Aufgaben im Rahmen dieses Kurses abzuschließen und überfällige Aufgaben in die Zukunft zu verschieben, können Sie noch heute ein Upgrade durchführen.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Es sieht so aus, als ob Sie einige wichtige, auf unserem vorgeschlagenen Zeitplan basierende Fristen verpasst haben. ";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Um den Zeitplan einzuhalten, können Sie ihn aktualisieren und die überfälligen Aufgaben in die Zukunft verschieben. Keine Sorge – Sie verlieren keinen Ihrer Fortschritte, wenn Sie Ihre Fälligkeitstermine verschieben.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Fälligkeitstermine verschieben";
 /* Course Dates Title */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -321,9 +321,9 @@
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
 /* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="It looks like you missed some important deadlines based on our suggested schedule. ";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines?";
 /* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.";
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Shift due dates";
 /* Course Dates Title */

--- a/Source/es-419.lproj/Localizable-2.strings
+++ b/Source/es-419.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for Discover*/
 "DISCOVER"="Discover";
 /*Title for Discovery*/

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -320,10 +320,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="lo que significa que no puedes participar en tareas calificadas. Parece que no cumpliste con algunos plazos importantes según nuestro calendario sugerido. Para completar las asignaciones calificadas como parte de este curso y cambiar las asignaciones vencidas al futuro, puedes cambiarte a la opción paga.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Cambiate a la opción paga para poder cambiar fechas de entrega";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Parece que no has cumplido con algunos plazos importantes según nuestro calendario sugerido.";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Para mantenerte en el camino adecuado, puedes actualizar este calendario y mover las tareas vencidas hacia el futuro. No te preocupes, no perderás nada de lo que hayas avanzado cuando cambies las fechas de entrega.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Cambia las fechas de entrega";
 /* Course Dates Title */

--- a/Source/fr.lproj/Localizable-2.strings
+++ b/Source/fr.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for dialog when user is leaving the app when tapped on link to be opened in external browser*/
 "LEAVING_APP_TITLE"="Leaving the app";
 /* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -320,10 +320,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="ce qui signifie que vous ne pouvez pas participer aux devoirs notés. Il semblerait que vous ayez manqué des échéances importantes de notre programme suggéré. Pour faire les devoirs notés dans le cadre de ce cours et pouvoir rendre les devoirs passés un peu plus tard, vous pouvez mettre à niveau votre inscription dès aujourd'hui.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Il semblerait que vous ayez manqué des échéances importantes de notre programme suggéré. ";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Pour rester sur la bonne voie, vous pouvez mettre à jour ce programme et rendre les devoirs passés un peu plus tard. Ne vous inquiétez pas : en modifiant les échéances, vous ne perdrez pas les progrès que vous avez faits.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Déplacer les dates d'échéances";
 /* Course Dates Title */

--- a/Source/he.lproj/Localizable-2.strings
+++ b/Source/he.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for dialog when user is leaving the app when tapped on link to be opened in external browser*/
 "LEAVING_APP_TITLE"="Leaving the app";
 /* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -328,10 +328,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="מה שאומר שאינך יכול להשתתף במטלות מדורגות. נראה שהחמצת כמה מועדים חשובים בהתבסס על לוח הזמנים המוצע שלנו. כדי להשלים מטלות מדורגות כחלק מהקורס הזה ולהעביר את המטלות שנקבעו בעבר אל העתיד, אתה יכול לשדרג היום.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="נראה שהחמצת כמה מועדים חשובים בהתבסס על לוח הזמנים המוצע שלנו. ";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="כדי לשמור על עצמכם על המסלול, תוכלו לעדכן את לוח הזמנים הזה ולהעביר את ההקצאות שהוגשו לעתיד. אל דאגה - לא תאבד שום התקדמות שהשגת כאשר תשנה את תאריכי היעד שלך.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="תאריכי יעד של משמרת";
 /* Course Dates Title */

--- a/Source/ja.lproj/Localizable-2.strings
+++ b/Source/ja.lproj/Localizable-2.strings
@@ -47,6 +47,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for dialog when user is leaving the app when tapped on link to be opened in external browser*/
 "LEAVING_APP_TITLE"="Leaving the app";
 /* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -316,10 +316,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="採点対象の課題には参加できません。推奨スケジュールにある重要な期限が守られなかったようです。このコースで採点対象の課題を完了し、過去の期限付き課題を未来日付に移動させるには、アップグレードしてください。";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="推奨スケジュールにある重要な期限が守られなかったようです。";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="このスケジュールを更新し、過去の課題を未来日付に移動させることで、学習を計画通りに進めることができます。期限をずらしてもこれまでの進捗が失われることはありませんので、ご安心ください。";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="期限を移動";
 /* Course Dates Title */

--- a/Source/pt-BR.lproj/Localizable-2.strings
+++ b/Source/pt-BR.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for dialog when user is leaving the app when tapped on link to be opened in external browser*/
 "LEAVING_APP_TITLE"="Leaving the app";
 /* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -321,10 +321,6 @@ Se você não conseguir acompanhar tudo nas datas sugeridas, você poderá ajust
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="o que significa que você não pode participar em avaliações. Para completar avaliações como uma parte deste curso, faça o upgrade hoje. Parece que você perdeu alguns prazos importantes baseados em nossa programação sugerida. Para completar avaliações como parte deste curso e adiar tarefas já atrasadas, faça o upgrade hoje.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Parece que você perdeu alguns prazos importantes baseados em nossa programação sugerida. ";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Para se ficar em dia, você pode atualizar esta programação e adiar as tarefas já atrasadas. Não se preocupe – você não perderá o progresso já feito.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Alterar datas de entrega";
 /* Course Dates Title */

--- a/Source/tr.lproj/Localizable-2.strings
+++ b/Source/tr.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for dialog when user is leaving the app when tapped on link to be opened in external browser*/
 "LEAVING_APP_TITLE"="Leaving the app";
 /* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -320,10 +320,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="dolayısıyla notlu ödevlere katılamazsınız. Önerilen programımıza göre bazı önemli son tarihleri kaçırmışsınız gibi görünüyor. Bu kursun parçası olarak notlu ödevler tamamlamak ve tarihi geçmiş ödevleri geleceğe taşımak için bugün yükseltme yapabilirsiniz.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Önerilen programımıza göre bazı önemli son tarihleri kaçırmışsınız gibi görünüyor. ";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Plana uygun kalmak için bu programı güncelleyebilir ve tarihi geçmiş ödevleri geleceğe taşıyabilirsiniz. Endişelenmeyin, bitiş tarihlerinizi değiştirdiğinizde ilerlemenizin hiçbir kısmını kaybetmeyeceksiniz.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Bitiş tarihlerini değiştir";
 /* Course Dates Title */

--- a/Source/vi.lproj/Localizable-2.strings
+++ b/Source/vi.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for dialog when user is leaving the app when tapped on link to be opened in external browser*/
 "LEAVING_APP_TITLE"="Leaving the app";
 /* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -316,10 +316,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="điều này có nghĩa là bạn không thể tham gia vào các bài tập chấm điểm. Có vẻ như bạn đã bỏ lỡ một số hạn chót quan trọng dựa trên lịch biểu gợi ý của chúng tôi. Để hoàn thành các bài tập chấm điểm thuộc khóa học này và di chuyển các bài tập đã quá hạn đến tương lai, bạn có thể nâng cấp hôm nay.";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Có vẻ như bạn đã bỏ lỡ một số hạn chót quan trọng dựa trên lịch biểu gợi ý của chúng tôi. ";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"=" Để duy trì đúng hướng đi, bạn có thể cập nhật lịch biểu này và di chuyển các bài tập đã quá hạn đến tương lai. Đừng lo lắng—bạn sẽ không mất bất kỳ tiến bộ nào mà bạn đã đạt được khi di chuyển ngày đến hạn.";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="Di chuyển ngày đến hạn";
 /* Course Dates Title */

--- a/Source/zh-Hans.lproj/Localizable-2.strings
+++ b/Source/zh-Hans.lproj/Localizable-2.strings
@@ -45,6 +45,10 @@
 "COURSE.AUDIT.EXPIRED_AGO" = "Access expired {time_duaration}";
 /* Course audit expired on date*/
 "COURSE.AUDIT.EXPIRED_ON" = "Expired on {expiry_date}";
+/* Course Reset Date Banner Header */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="Missed some deadlines? ";
+/* Course Reset Date Banner Body */
+"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="Don't worry - shift our suggested schedule to complete past due assignments without losing any progress.";
 /*Title for dialog when user is leaving the app when tapped on link to be opened in external browser*/
 "LEAVING_APP_TITLE"="Leaving the app";
 /* Message for dialog when user is leaving the app when tapped on link to be opened in external browser */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -316,10 +316,6 @@
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BODY"="这意味着你不能参加分级作业。根据我们建议的日程安排，您似乎错过了一些重要的截止日期。要完成本课程一部分的分级作业，并将过去到期的作业转移到未来，您可以今天进行功能升级。";
 /* Course Reset Date Upgrade Reset Banner Button */
 "COURSEDATES.RESET_DATE.UPGRADE_TO_RESET_BANNER.BUTTON"="Upgrade to shift due dates";
-/* Course Reset Date Banner Header */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.HEADER"="根据我们建议的日程安排，您似乎错过了一些重要的截止日期。";
-/* Course Reset Date Banner Body */
-"COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BODY"="为了让自己赶上进程，您可以更新此计划并将过期的任务转移到未来。不要担心，当你改变你的截止日期时，你不会失去你已经取得的任何过程记录。";
 /* Course Reset Date Banner Button */
 "COURSEDATES.RESET_DATE.RESET_DATE_BANNER.BUTTON"="改变截止日期";
 /* Course Dates Title */

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -862,6 +862,7 @@
 		E0D159951EB87699005E2A76 /* WhatsNewDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D159941EB87699005E2A76 /* WhatsNewDataModel.swift */; };
 		E0D159971EB87700005E2A76 /* WhatsNewObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D159961EB87700005E2A76 /* WhatsNewObject.swift */; };
 		E0D232D4291374A900051A04 /* UsingExternalAuthInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D232D3291374A900051A04 /* UsingExternalAuthInfoView.swift */; };
+		E0D31F0729E6A0A600044368 /* NewCourseDateBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D31F0629E6A0A600044368 /* NewCourseDateBannerView.swift */; };
 		E0E163EC21368A1D00DAE9F0 /* FirebaseConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E163EB21368A1D00DAE9F0 /* FirebaseConfig.swift */; };
 		E0E163EE21368A4F00DAE9F0 /* FirebaseConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E163ED21368A4F00DAE9F0 /* FirebaseConfigTests.swift */; };
 		E0E163F021368A6300DAE9F0 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E0E163EF21368A6300DAE9F0 /* GoogleService-Info.plist */; };
@@ -2023,6 +2024,7 @@
 		E0D159941EB87699005E2A76 /* WhatsNewDataModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhatsNewDataModel.swift; sourceTree = "<group>"; };
 		E0D159961EB87700005E2A76 /* WhatsNewObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhatsNewObject.swift; sourceTree = "<group>"; };
 		E0D232D3291374A900051A04 /* UsingExternalAuthInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsingExternalAuthInfoView.swift; sourceTree = "<group>"; };
+		E0D31F0629E6A0A600044368 /* NewCourseDateBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCourseDateBannerView.swift; sourceTree = "<group>"; };
 		E0E163EB21368A1D00DAE9F0 /* FirebaseConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseConfig.swift; sourceTree = "<group>"; };
 		E0E163ED21368A4F00DAE9F0 /* FirebaseConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseConfigTests.swift; sourceTree = "<group>"; };
 		E0E163EF21368A6300DAE9F0 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -2354,6 +2356,7 @@
 				5F28980B2507B19400BF76DF /* CourseDateBannerView.swift */,
 				5FD868352637F05E0045A149 /* CourseDatesHeaderView.swift */,
 				5FD868372637F0FC0045A149 /* CalendarManager.swift */,
+				E0D31F0629E6A0A600044368 /* NewCourseDateBannerView.swift */,
 			);
 			name = "Course Dates";
 			sourceTree = "<group>";
@@ -4921,6 +4924,7 @@
 			files = (
 				5FD868382637F0FC0045A149 /* CalendarManager.swift in Sources */,
 				22A970E824EED00E008FCAF6 /* AppleAuthProvider.swift in Sources */,
+				E0D31F0729E6A0A600044368 /* NewCourseDateBannerView.swift in Sources */,
 				77E6486E1C912DA200B6740D /* NetworkManager+StandardInterceptors.swift in Sources */,
 				7742F8DD1C3C979D009E555A /* DiscoveryConfig.swift in Sources */,
 				9E71B73F1B1D9DBD009C81E2 /* OEXStyles+Swift.swift in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-9086](https://2u-internal.atlassian.net/browse/LEARNER-9086)

[LEARNER-9365](https://2u-internal.atlassian.net/browse/LEARNER-9365)

Note: Add `NEW_DASHBOARD_ENABLED: true` in the local configuration file to enable new dashboard. The course dates shift banner will appears in the course header when the server returns that dates needs shifting (`shift_dates`).

<img src="https://github.com/openedx/edx-app-ios/assets/5606473/e2d71c7e-eb83-4b0e-941e-0829cfdb89c3" width="300" height="700" />

