### PR TITLE
fix: show first component of complted subsection

### DIFF
--- a/Source/NewCourseContentController.swift
+++ b/Source/NewCourseContentController.swift
@@ -193,7 +193,7 @@ class NewCourseContentController: UIViewController, InterfaceOrientationOverridi
             } ?? []
         }
 
-        currentBlock = blocks.first(where: { !$0.isCompleted }) ?? blocks.last
+        currentBlock = blocks.first(where: { !$0.isCompleted }) ?? blocks.first
     }
     
     private func updateView() {


### PR DESCRIPTION
### Description

[LEARNER-9697](https://2u-internal.atlassian.net/browse/LEARNER-9697)

This PR updates unit navigation and shows first component of the completed subsection
