### PR TITLE
fix: Learners can't sync courses to calendar on iPhone

### DIFF
--- a/Source/edX-Info.plist
+++ b/Source/edX-Info.plist
@@ -84,6 +84,8 @@
 	</dict>
 	<key>NSCalendarsUsageDescription</key>
 	<string>edX would like to use your calendar list to subscribe to your personalized edX calendar for this course.</string>
+    <key>NSCalendarsFullAccessUsageDescription</key>
+    <string>edX would like to use your calendar list to subscribe to your personalized edX calendar for this course.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>so you can take a picture for a profile image</string>
 	<key>NSContactsUsageDescription</key>


### PR DESCRIPTION
### Description

[LEARNER-9807](https://2u-internal.atlassian.net/browse/LEARNER-9807)
Prior to this update, individuals using iPhones with iOS 17 or later were unable to synchronize courses with the calendar on their devices. The problem stemmed from the utilization of a deprecated function for accessing calendar events permissions.

**Deprecated Function of `EKEventStore`:**
```
requestAccess(to:completion:)
For iOS 17 and subsequent versions, utilizing this method does not trigger an access prompt; instead, it promptly invokes the completion block with an error.
```

Within this pull request, we have incorporated a new method for the `EKEventStore` that is compatible with iOS 17 and later versions.
```
requestFullAccessToEvents(completion:)
```

Additionally, included the `NSCalendarsFullAccessUsageDescription` key in the `Source/edX-Info.plist` file.

### How to test this PR
- To assess this pull request, it is necessary to possess an iPhone running iOS 17 or a newer version. Navigate to any course and access its dates section for testing.
- Enable the "Sync to calendar" option, and you should observe a prompt requesting calendar permissions.
