### PR TITLE
fix: Add Support For Hours, Minutes and Seconds in Dates

### DIFF
--- a/Source/CourseDates.swift
+++ b/Source/CourseDates.swift
@@ -462,7 +462,7 @@ fileprivate extension Date {
         }
         
         calender.timeZone = timeZone
-        let components = calender.dateComponents([.year, .month, .day], from: self)
+        let components = calender.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self)
         
         return calender.date(from: components) ?? self
     }


### PR DESCRIPTION
### Description

[LEARNER-9936](https://2u-internal.atlassian.net/browse/LEARNER-9936)

Implemented support for hours, minutes, and seconds in dates to prevent calendar synchronization update alerts when replacing the production application with the new codebase.

Prior to merging this PR, all calendar events were being added to the mobile native calendar at the timestamp of **04:00AM to 05:00AM** because we were previously disregarding hours, minutes, and seconds. Therefore, we are now taking them into account, ensuring that calendar events are added at the exact time received from the backend.

| Before | After |
|----------|----------|
| ![Simulator Screenshot - iPhone 15 - 2024-04-19 at 18 00 31](https://github.com/openedx/edx-app-ios/assets/11990137/e9bded42-e79d-4d82-8791-d80b2a1b2e0d) | ![Simulator Screenshot - iPhone 15 - 2024-04-19 at 17 51 47](https://github.com/openedx/edx-app-ios/assets/11990137/f2b38189-c7c4-4d2f-9e56-17fbfff32b0d) |
| ![Simulator Screenshot - iPhone 15 - 2024-04-19 at 18 00 35](https://github.com/openedx/edx-app-ios/assets/11990137/a9a24811-8fea-404f-9260-f766ac0c3a11) | ![Simulator Screenshot - iPhone 15 - 2024-04-19 at 17 51 53](https://github.com/openedx/edx-app-ios/assets/11990137/09958e99-d6b4-47da-ace8-17d03fee253b) |

### How to test this PR
We can assess it by observing the behavior of the production application and then comparing it with the behavior on this branch.